### PR TITLE
impl get secrets from backbone server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,6 +3693,7 @@ checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
 dependencies = [
  "getrandom",
  "rand",
+ "serde",
  "web-time",
 ]
 

--- a/crates/tessera-backbone/Cargo.toml
+++ b/crates/tessera-backbone/Cargo.toml
@@ -22,7 +22,7 @@ sea-orm = { workspace = true, features = [ "mock" ] }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }
 aws-sigv4 = { workspace = true }
-ulid = { workspace = true }
+ulid = { workspace = true, features = [ "serde" ] }
 url = { workspace = true }
 urlencoding = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/tessera-backbone/src/application/mod.rs
+++ b/crates/tessera-backbone/src/application/mod.rs
@@ -10,6 +10,9 @@ use crate::{
 
 use workspace::{WorkspaceUseCase, WorkspaceUseCaseImpl};
 
+use self::secret::{SecretUseCase, SecretUseCaseImpl};
+
+pub mod secret;
 pub mod workspace;
 
 pub(crate) struct Application {
@@ -20,6 +23,24 @@ pub(crate) struct Application {
 impl Application {
     pub fn workspace(&self) -> impl WorkspaceUseCase {
         WorkspaceUseCaseImpl::new(self.database_connection.clone(), self.workspace_service.clone())
+    }
+
+    pub fn with_workspace(&self, workspace_name: &str) -> ApplicationWithWorkspace {
+        ApplicationWithWorkspace::new(workspace_name.to_owned())
+    }
+}
+
+pub(crate) struct ApplicationWithWorkspace {
+    workspace_name: String,
+}
+
+impl ApplicationWithWorkspace {
+    pub fn new(workspace_name: String) -> Self {
+        Self { workspace_name }
+    }
+
+    pub fn secret(&self) -> impl SecretUseCase {
+        SecretUseCaseImpl::new(self.workspace_name.to_owned())
     }
 }
 

--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -88,7 +88,7 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 mod test {
     use std::{str::FromStr, sync::Arc};
 
-    use sea_orm::{DatabaseBackend, DbErr, MockDatabase, MockExecResult};
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
     use ulid::Ulid;
 
     use crate::domain::secret::{MockSecretService, SecretEntry};

--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -1,5 +1,16 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
+use sea_orm::DatabaseConnection;
 use ulid::Ulid;
+
+use crate::{
+    database::OrganizationScopedTransaction,
+    domain::{
+        self,
+        secret::{Secret, SecretService},
+    },
+};
 
 #[async_trait]
 pub(crate) trait SecretUseCase {
@@ -8,18 +19,28 @@ pub(crate) trait SecretUseCase {
 
 pub(crate) struct SecretUseCaseImpl {
     workspace_name: String,
+    database_connection: Arc<DatabaseConnection>,
+    secret_service: Arc<dyn SecretService + Sync + Send>,
 }
 
 impl SecretUseCaseImpl {
-    pub fn new(workspace_name: String) -> Self {
-        Self { workspace_name }
+    pub fn new(
+        workspace_name: String,
+        database_connection: Arc<DatabaseConnection>,
+        secret_service: Arc<dyn SecretService + Sync + Send>,
+    ) -> Self {
+        Self { workspace_name, database_connection, secret_service }
     }
 }
 
 #[async_trait]
 impl SecretUseCase for SecretUseCaseImpl {
-    async fn list(&self, _path: &str) -> Result<Vec<SecretData>> {
-        todo!()
+    async fn list(&self, path: &str) -> Result<Vec<SecretData>> {
+        let transaction = self.database_connection.begin_with_organization_scope(&self.workspace_name).await?;
+        let secrets = self.secret_service.list(&transaction, path).await?;
+        transaction.commit().await?;
+
+        Ok(secrets.into_iter().map(SecretData::from).collect())
     }
 }
 
@@ -31,5 +52,32 @@ pub(crate) struct SecretData {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum Error {}
+pub(crate) enum Error {
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+impl From<sea_orm::DbErr> for Error {
+    fn from(value: sea_orm::DbErr) -> Self {
+        Self::Anyhow(value.into())
+    }
+}
+
+impl From<domain::secret::Error> for Error {
+    fn from(value: domain::secret::Error) -> Self {
+        match value {}
+    }
+}
+
+impl From<Secret> for SecretData {
+    fn from(value: Secret) -> Self {
+        Self {
+            key: value.key,
+            path: value.path,
+            reader_policy_ids: value.reader_policy_ids,
+            writer_policy_ids: value.writer_policy_ids,
+        }
+    }
+}
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     database::OrganizationScopedTransaction,
     domain::{
         self,
-        secret::{Secret, SecretService},
+        secret::{SecretEntry, SecretService},
     },
 };
 
@@ -65,12 +65,14 @@ impl From<sea_orm::DbErr> for Error {
 
 impl From<domain::secret::Error> for Error {
     fn from(value: domain::secret::Error) -> Self {
-        match value {}
+        match value {
+            domain::secret::Error::Anyhow(e) => Self::Anyhow(e),
+        }
     }
 }
 
-impl From<Secret> for SecretData {
-    fn from(value: Secret) -> Self {
+impl From<SecretEntry> for SecretData {
+    fn from(value: SecretEntry) -> Self {
         Self {
             key: value.key,
             path: value.path,

--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use ulid::Ulid;
+
+#[async_trait]
+pub(crate) trait SecretUseCase {
+    async fn list(&self, path: &str) -> Result<Vec<SecretData>>;
+}
+
+pub(crate) struct SecretUseCaseImpl {
+    workspace_name: String,
+}
+
+impl SecretUseCaseImpl {
+    pub fn new(workspace_name: String) -> Self {
+        Self { workspace_name }
+    }
+}
+
+#[async_trait]
+impl SecretUseCase for SecretUseCaseImpl {
+    async fn list(&self, _path: &str) -> Result<Vec<SecretData>> {
+        todo!()
+    }
+}
+
+pub(crate) struct SecretData {
+    pub key: String,
+    pub path: String,
+    pub reader_policy_ids: Vec<Ulid>,
+    pub writer_policy_ids: Vec<Ulid>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {}
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/crates/tessera-backbone/src/database/applied_policy.rs
+++ b/crates/tessera-backbone/src/database/applied_policy.rs
@@ -1,0 +1,41 @@
+use chrono::{DateTime, Utc};
+use sea_orm::prelude::*;
+
+use super::UlidId;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "applied_policy")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: UlidId,
+    pub secret_metadata_id: UlidId,
+    pub r#type: PolicyApplicationType,
+    pub policy_id: UlidId,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(EnumIter, DeriveActiveEnum, Clone, Debug, PartialEq)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::None)", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PolicyApplicationType {
+    Read,
+    Write,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::secret_metadata::Entity",
+        from = "Column::SecretMetadataId",
+        to = "super::secret_metadata::Column::Id"
+    )]
+    SecretMetadata,
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+impl Related<super::secret_metadata::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::SecretMetadata.def()
+    }
+}

--- a/crates/tessera-backbone/src/database/mod.rs
+++ b/crates/tessera-backbone/src/database/mod.rs
@@ -21,6 +21,7 @@ use sea_orm::{
 use ulid::Ulid;
 use url::Url;
 
+pub(crate) mod secret_metadata;
 pub(crate) mod workspace;
 
 pub(crate) enum AuthMethod {

--- a/crates/tessera-backbone/src/database/mod.rs
+++ b/crates/tessera-backbone/src/database/mod.rs
@@ -21,6 +21,7 @@ use sea_orm::{
 use ulid::Ulid;
 use url::Url;
 
+pub(crate) mod applied_policy;
 pub(crate) mod secret_metadata;
 pub(crate) mod workspace;
 
@@ -134,17 +135,17 @@ fn reassign_token_periodically_to_database(
 
 #[async_trait]
 pub trait OrganizationScopedTransaction {
-    async fn begin_with_organization_scope(&self, organization_slug: &str) -> Result<DatabaseTransaction, DbErr>;
+    async fn begin_with_organization_scope(&self, workspace_slug: &str) -> Result<DatabaseTransaction, DbErr>;
 }
 
 #[async_trait]
 impl OrganizationScopedTransaction for DatabaseConnection {
-    async fn begin_with_organization_scope(&self, organization_slug: &str) -> Result<DatabaseTransaction, DbErr> {
+    async fn begin_with_organization_scope(&self, workspace_slug: &str) -> Result<DatabaseTransaction, DbErr> {
         let transaction = self.begin().await?;
         transaction
             .execute(Statement::from_string(
                 DatabaseBackend::Postgres,
-                format!("SET LOCAL search_path TO \"{organization_slug}\", \"public\";"),
+                format!("SET LOCAL search_path TO \"{workspace_slug}\", \"public\";"),
             ))
             .await?;
 

--- a/crates/tessera-backbone/src/database/secret_metadata.rs
+++ b/crates/tessera-backbone/src/database/secret_metadata.rs
@@ -1,0 +1,20 @@
+use chrono::{DateTime, Utc};
+use sea_orm::prelude::*;
+
+use super::UlidId;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "secret_metadata")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: UlidId,
+    pub key: String,
+    pub path: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tessera-backbone/src/database/secret_metadata.rs
+++ b/crates/tessera-backbone/src/database/secret_metadata.rs
@@ -15,6 +15,15 @@ pub struct Model {
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-pub enum Relation {}
+pub enum Relation {
+    #[sea_orm(has_many = "super::applied_policy::Entity")]
+    AppliedPolicy,
+}
 
 impl ActiveModelBehavior for ActiveModel {}
+
+impl Related<super::applied_policy::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::AppliedPolicy.def()
+    }
+}

--- a/crates/tessera-backbone/src/domain/mod.rs
+++ b/crates/tessera-backbone/src/domain/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod secret;
 pub(crate) mod workspace;

--- a/crates/tessera-backbone/src/domain/secret/mod.rs
+++ b/crates/tessera-backbone/src/domain/secret/mod.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+#[cfg(test)]
+use mockall::automock;
 use sea_orm::{ColumnTrait, DatabaseTransaction, EntityTrait, LoaderTrait, QueryFilter};
 use ulid::Ulid;
 
@@ -11,6 +13,7 @@ pub(crate) struct SecretEntry {
     pub writer_policy_ids: Vec<Ulid>,
 }
 
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub(crate) trait SecretService {
     async fn list(&self, transaction: &DatabaseTransaction, path_prefix: &str) -> Result<Vec<SecretEntry>>;
@@ -65,3 +68,86 @@ impl From<sea_orm::DbErr> for Error {
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod test {
+    use std::{str::FromStr, sync::Arc};
+
+    use chrono::Utc;
+    use sea_orm::{DatabaseBackend, DbErr, MockDatabase, TransactionTrait};
+    use ulid::Ulid;
+
+    use super::{Error, PostgresSecretService, SecretService};
+    use crate::database::{applied_policy, secret_metadata, UlidId};
+
+    #[tokio::test]
+    async fn when_getting_secret_data_is_successful_then_secret_service_returns_secrets_ok() {
+        let now = Utc::now();
+        let metadata_id = UlidId::new(Ulid::from_str("01JACYVTYB4F2PEBFRG1BB7BKP").unwrap());
+        let key = "TEST_KEY";
+        let path = "/test/path";
+        let applied_policy_ids = [
+            UlidId::new(Ulid::from_str("01JACZ1B5W5Z3D9R1CVYB7JJ8S").unwrap()),
+            UlidId::new(Ulid::from_str("01JACZ1FG1RYABQW2KB6YSEZ84").unwrap()),
+        ];
+        let policy_id = UlidId::new(Ulid::from_str("01JACZ44MJDY5GD21X2W910CFV").unwrap());
+
+        let mock_database = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![secret_metadata::Model {
+                id: metadata_id.to_owned(),
+                key: key.to_owned(),
+                path: path.to_owned(),
+                created_at: now,
+                updated_at: now,
+            }]])
+            .append_query_results([vec![
+                applied_policy::Model {
+                    id: applied_policy_ids[0].to_owned(),
+                    secret_metadata_id: metadata_id.to_owned(),
+                    r#type: applied_policy::PolicyApplicationType::Read,
+                    policy_id: policy_id.to_owned(),
+                    created_at: now,
+                    updated_at: now,
+                },
+                applied_policy::Model {
+                    id: applied_policy_ids[1].to_owned(),
+                    secret_metadata_id: metadata_id.to_owned(),
+                    r#type: applied_policy::PolicyApplicationType::Write,
+                    policy_id: policy_id.to_owned(),
+                    created_at: now,
+                    updated_at: now,
+                },
+            ]]);
+
+        let mock_connection = Arc::new(mock_database.into_connection());
+
+        let secret_service = PostgresSecretService {};
+
+        let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
+
+        let result = secret_service.list(&transaction, "/").await.expect("creating workspace should be successful");
+        transaction.commit().await.expect("commiting transaction should be successful");
+
+        assert_eq!(result[0].key, key);
+        assert_eq!(result[0].path, path);
+        assert_eq!(result[0].reader_policy_ids[0], Ulid::from_str("01JACZ1B5W5Z3D9R1CVYB7JJ8S").unwrap());
+        assert_eq!(result[0].writer_policy_ids[0], Ulid::from_str("01JACZ1FG1RYABQW2KB6YSEZ84").unwrap());
+    }
+
+    #[tokio::test]
+    async fn when_getting_secret_is_failed_then_secret_service_returns_anyhow_err() {
+        let mock_database = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_errors(vec![DbErr::Custom("some error".to_owned())]);
+        let mock_connection = Arc::new(mock_database.into_connection());
+
+        let secret_service = PostgresSecretService {};
+
+        let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
+
+        let result = secret_service.list(&transaction, "/").await;
+        transaction.commit().await.expect("commiting transaction should be successful");
+
+        assert!(matches!(result, Err(Error::Anyhow(_))));
+        assert_eq!(result.err().unwrap().to_string(), "Custom Error: some error");
+    }
+}

--- a/crates/tessera-backbone/src/domain/secret/mod.rs
+++ b/crates/tessera-backbone/src/domain/secret/mod.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+use sea_orm::DatabaseTransaction;
+use ulid::Ulid;
+
+pub(crate) struct Secret {
+    pub key: String,
+    pub path: String,
+    pub reader_policy_ids: Vec<Ulid>,
+    pub writer_policy_ids: Vec<Ulid>,
+}
+
+#[async_trait]
+pub(crate) trait SecretService {
+    async fn list(&self, transaction: &DatabaseTransaction, path_prefix: &str) -> Result<Vec<Secret>>;
+}
+
+pub(crate) struct PostgresSecretService {
+}
+
+#[async_trait]
+impl SecretService for PostgresSecretService {
+    async fn list(&self, _transaction: &DatabaseTransaction, _path_prefix: &str) -> Result<Vec<Secret>> {
+        todo!()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {}
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/crates/tessera-backbone/src/domain/secret/mod.rs
+++ b/crates/tessera-backbone/src/domain/secret/mod.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
-use sea_orm::DatabaseTransaction;
+use sea_orm::{ColumnTrait, DatabaseTransaction, EntityTrait, QueryFilter};
 use ulid::Ulid;
 
-pub(crate) struct Secret {
+use crate::database::secret_metadata;
+
+pub(crate) struct SecretEntry {
     pub key: String,
     pub path: String,
     pub reader_policy_ids: Vec<Ulid>,
@@ -11,19 +13,43 @@ pub(crate) struct Secret {
 
 #[async_trait]
 pub(crate) trait SecretService {
-    async fn list(&self, transaction: &DatabaseTransaction, path_prefix: &str) -> Result<Vec<Secret>>;
+    async fn list(&self, transaction: &DatabaseTransaction, path_prefix: &str) -> Result<Vec<SecretEntry>>;
 }
 
-pub(crate) struct PostgresSecretService {
-}
+pub(crate) struct PostgresSecretService {}
 
 #[async_trait]
 impl SecretService for PostgresSecretService {
-    async fn list(&self, _transaction: &DatabaseTransaction, _path_prefix: &str) -> Result<Vec<Secret>> {
-        todo!()
+    async fn list(&self, transaction: &DatabaseTransaction, path_prefix: &str) -> Result<Vec<SecretEntry>> {
+        let metadata = secret_metadata::Entity::find()
+            .filter(secret_metadata::Column::Path.like(format!("{path_prefix}%")))
+            .all(transaction)
+            .await?;
+
+        let entries = metadata
+            .into_iter()
+            .map(|metadata| SecretEntry {
+                key: metadata.key,
+                path: metadata.path,
+                reader_policy_ids: vec![],
+                writer_policy_ids: vec![],
+            })
+            .collect();
+
+        Ok(entries)
     }
 }
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum Error {}
+pub(crate) enum Error {
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}
+
+impl From<sea_orm::DbErr> for Error {
+    fn from(value: sea_orm::DbErr) -> Self {
+        Self::Anyhow(value.into())
+    }
+}
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/crates/tessera-backbone/src/server/mod.rs
+++ b/crates/tessera-backbone/src/server/mod.rs
@@ -20,7 +20,9 @@ impl From<&ApplicationConfig> for ServerConfig {
 
 pub(super) async fn run(application: Application, config: ServerConfig) -> anyhow::Result<()> {
     let application = Arc::new(application);
-    let app = Router::new().nest("/workspaces", router::workspace::router(application.clone()));
+    let app = Router::new()
+        .nest("/workspaces", router::workspace::router(application.clone()))
+        .nest("/", router::secret::router(application.clone()));
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", config.port)).await?;
     debug!("starting backbone server on {}", config.port);
     axum::serve(listener, app).await?;

--- a/crates/tessera-backbone/src/server/router/mod.rs
+++ b/crates/tessera-backbone/src/server/router/mod.rs
@@ -1,1 +1,2 @@
-pub mod workspace;
+pub(crate) mod secret;
+pub(crate) mod workspace;

--- a/crates/tessera-backbone/src/server/router/secret/mod.rs
+++ b/crates/tessera-backbone/src/server/router/secret/mod.rs
@@ -20,7 +20,7 @@ use self::response::SecretResponse;
 mod response;
 
 pub(crate) fn router(application: Arc<Application>) -> axum::Router {
-    Router::new().route("/:workspace_name/secrets", get(handle_get_secrets)).with_state(application)
+    Router::new().route("/workspaces/:workspace_name/secrets", get(handle_get_secrets)).with_state(application)
 }
 
 #[derive(Deserialize)]

--- a/crates/tessera-backbone/src/server/router/secret/mod.rs
+++ b/crates/tessera-backbone/src/server/router/secret/mod.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use axum::{
+    debug_handler,
+    extract::{Path, Query, State},
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use serde::Deserialize;
+
+use crate::application::{
+    self,
+    secret::{SecretData, SecretUseCase},
+    Application,
+};
+
+use self::response::SecretResponse;
+
+mod response;
+
+pub(crate) fn router(application: Arc<Application>) -> axum::Router {
+    Router::new().route("/:workspace_name/secrets", get(handle_get_secrets)).with_state(application)
+}
+
+#[derive(Deserialize)]
+struct GetSecretsApiQueryParam {
+    path: Option<String>,
+}
+
+#[debug_handler]
+async fn handle_get_secrets(
+    Path(workspace_name): Path<String>,
+    Query(query_params): Query<GetSecretsApiQueryParam>,
+    State(application): State<Arc<Application>>,
+) -> Result<impl IntoResponse, application::secret::Error> {
+    let secrets =
+        application.with_workspace(&workspace_name).secret().list(query_params.path.as_deref().unwrap_or("/")).await?;
+    let response: Vec<SecretResponse> = secrets.into_iter().map(SecretResponse::from).collect();
+
+    Ok(Json(response))
+}
+
+impl From<SecretData> for SecretResponse {
+    fn from(value: SecretData) -> Self {
+        Self {
+            key: value.key,
+            path: value.path,
+            reader_policy_ids: value.reader_policy_ids,
+            writer_policy_ids: value.writer_policy_ids,
+        }
+    }
+}

--- a/crates/tessera-backbone/src/server/router/secret/response/mod.rs
+++ b/crates/tessera-backbone/src/server/router/secret/response/mod.rs
@@ -1,0 +1,18 @@
+use crate::application;
+use axum::response::IntoResponse;
+use serde::Serialize;
+use ulid::Ulid;
+
+impl IntoResponse for application::secret::Error {
+    fn into_response(self) -> axum::response::Response {
+        match self {}
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct SecretResponse {
+    pub key: String,
+    pub path: String,
+    pub reader_policy_ids: Vec<Ulid>,
+    pub writer_policy_ids: Vec<Ulid>,
+}

--- a/crates/tessera-backbone/src/server/router/secret/response/mod.rs
+++ b/crates/tessera-backbone/src/server/router/secret/response/mod.rs
@@ -1,11 +1,13 @@
-use crate::application;
+use crate::{application, server::response::handle_internal_server_error};
 use axum::response::IntoResponse;
 use serde::Serialize;
 use ulid::Ulid;
 
 impl IntoResponse for application::secret::Error {
     fn into_response(self) -> axum::response::Response {
-        match self {}
+        match self {
+            application::secret::Error::Anyhow(e) => handle_internal_server_error(&*e).into_response(),
+        }
     }
 }
 


### PR DESCRIPTION
# impl get secrets from backbone server

<!-- Thank you for submitting a pull request to our repo. -->

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

- Implement a feature to retrieve a list of secrets excluding the ones accessed from secret storage.

## Description

This pull request implements the secret retrieval feature for the backbone server. In this pull request, only the implementation using the PostgreSQL repository is included. The feature for retrieving the encrypted secrets will need to be added after the storage implementation is completed.