### PR TITLE
refactor: update lifetime annotations in AESShieldStorage

### DIFF
--- a/crates/tessera-storage/src/backend/file.rs
+++ b/crates/tessera-storage/src/backend/file.rs
@@ -29,7 +29,7 @@ impl<'a> Storage for FileStorage<'a> {
     type Key = str;
     type Value = [u8];
 
-    type StorageError = FileStorageError<'a>;
+    type StorageError = FileStorageError<'static>;
 
     async fn get(&self, key: &Self::Key) -> Result<<Self::Value as ToOwned>::Owned, Self::StorageError> {
         let path = self.path.clone().into_owned().join(key);

--- a/crates/tessera-storage/src/shield/mod.rs
+++ b/crates/tessera-storage/src/shield/mod.rs
@@ -4,11 +4,11 @@ pub mod aes;
 
 #[trait_variant::make(Shield: Send)]
 pub trait LocalShield {
-    type ShieldError: std::error::Error;
+    type ShieldError<'error>: std::error::Error;
     type Key: ToOwned + ?Sized;
     type ZeroizingKey: ZeroizeOnDrop;
-    async fn initialize(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError>;
-    async fn armor(&self) -> Result<(), Self::ShieldError>;
-    async fn disarm(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError>;
-    async fn generate_key(&self) -> Result<Self::ZeroizingKey, Self::ShieldError>;
+    async fn initialize<'a>(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError<'a>>;
+    async fn armor<'a>(&self) -> Result<(), Self::ShieldError<'a>>;
+    async fn disarm<'a>(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError<'a>>;
+    async fn generate_key<'a>(&self) -> Result<Self::ZeroizingKey, Self::ShieldError<'a>>;
 }


### PR DESCRIPTION
# refactor: update lifetime annotations in AESShieldStorage

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This pull request refactors the lifetime annotations in the `AESShieldStorage` module to enhance memory safety and clarify ownership semantics. The updates aim to improve code readability and maintainability without altering the existing functionality.
