### PR TITLE
feat(storage): update storage get methods to return Option type

### DIFF
--- a/crates/tessera-storage/src/lib.rs
+++ b/crates/tessera-storage/src/lib.rs
@@ -6,7 +6,7 @@ pub trait LocalStorage {
     type Key: ToOwned + ?Sized + Sync;
     type Value: ToOwned + ?Sized + Sync;
     type StorageError: std::error::Error;
-    async fn get(&self, key: &Self::Key) -> Result<<Self::Value as ToOwned>::Owned, Self::StorageError>;
+    async fn get(&self, key: &Self::Key) -> Result<Option<<Self::Value as ToOwned>::Owned>, Self::StorageError>;
     async fn set(&self, key: &Self::Key, value: &Self::Value) -> Result<(), Self::StorageError>;
     async fn delete(&self, key: &Self::Key) -> Result<(), Self::StorageError>;
     async fn list(


### PR DESCRIPTION
# feat(storage): update storage get methods to return Option type

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.



## Description

This pull request updates the storage get methods to return an Option type instead of a standard type. This change will improve the handling of non-existent values, allowing for more robust and safer code by utilizing Rust's option types. 


