### PR TITLE
fix(abe): add Clone derive to several structs for better usability

### DIFF
--- a/crates/tessera-abe-wasm/src/lib.rs
+++ b/crates/tessera-abe-wasm/src/lib.rs
@@ -25,7 +25,6 @@ static ALLOCATOR: LockedAllocator<FreeListAllocator> = LockedAllocator::new(Free
 pub fn bls_24479_encryption(data: &str, gp: JsValue, pks: JsValue, policy: JsValue) -> Result<JsValue, JsValue> {
     let global_params: GlobalParams<Bls24479Curve> = serde_wasm_bindgen::from_value(gp)?;
     let pks: HashMap<String, AuthorityPublicKey<Bls24479Curve>> = serde_wasm_bindgen::from_value(pks)?;
-    let pks = pks.iter().map(|(k, v)| (k.clone(), v)).collect::<HashMap<_, &_>>();
     let policy: (String, PolicyLanguage) = serde_wasm_bindgen::from_value(policy)?;
     let mut rng = MiraclRng::new();
     let mut seed = [0u8; 32];

--- a/crates/tessera-abe/src/curves/bls24479.rs
+++ b/crates/tessera-abe/src/curves/bls24479.rs
@@ -459,7 +459,7 @@ impl Inv for Gt {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Bls24479Curve;
 
 impl PairingCurve for Bls24479Curve {

--- a/crates/tessera-abe/src/curves/bls48556.rs
+++ b/crates/tessera-abe/src/curves/bls48556.rs
@@ -459,7 +459,7 @@ impl Inv for Gt {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Bls48556Curve;
 
 impl PairingCurve for Bls48556Curve {

--- a/crates/tessera-abe/src/curves/mod.rs
+++ b/crates/tessera-abe/src/curves/mod.rs
@@ -146,7 +146,7 @@ where
     fn one() -> Self;
 }
 
-pub trait PairingCurve {
+pub trait PairingCurve: Sized + Clone {
     type Rng: CryptoRng + RngCore;
     type Field: FieldWithOrder<Rng = Self::Rng>;
     type G1: GroupG1<Field = Self::Field>;

--- a/crates/tessera-abe/src/schemes/rw15.rs
+++ b/crates/tessera-abe/src/schemes/rw15.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::HashMap};
 use tessera_policy::pest::{parse, PolicyLanguage};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct GlobalParams<T>
 where
     T: PairingCurve,
@@ -38,20 +38,20 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AuthorityKeyPair<T: PairingCurve> {
     pub name: String,
     pub pk: AuthorityPublicKey<T>,
     pub mk: AuthorityMasterKey<T>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AuthorityPublicKey<T: PairingCurve> {
     pub e_alpha: T::Gt,
     pub gy: T::G1,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AuthorityMasterKey<T: PairingCurve> {
     pub alpha: T::Field,
     pub y: T::Field,
@@ -78,13 +78,13 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct UserAttributeKey<T: PairingCurve> {
     pub k: T::G2,
     pub kp: T::G1,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct UserSecretKey<T: PairingCurve> {
     pub gid: String,
     pub inner: HashMap<String, UserAttributeKey<T>>,
@@ -160,7 +160,7 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Ciphertext<T: PairingCurve> {
     pub policy: (String, PolicyLanguage),
     pub c0: T::Gt,
@@ -168,7 +168,7 @@ pub struct Ciphertext<T: PairingCurve> {
     pub ct: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Cx<T: PairingCurve> {
     pub c1: T::Gt,
     pub c2: T::G1,
@@ -179,7 +179,7 @@ pub struct Cx<T: PairingCurve> {
 pub fn encrypt<'a, T: PairingCurve>(
     rng: &mut <T::Field as Random>::Rng,
     gp: &GlobalParams<T>,
-    pks: &HashMap<String, &AuthorityPublicKey<T>>,
+    pks: &HashMap<String, AuthorityPublicKey<T>>,
     policy: (String, PolicyLanguage),
     data: &[u8],
 ) -> Result<Ciphertext<T>, ABEError<'a>> {
@@ -358,9 +358,9 @@ mod tests {
         let mut rng = rng();
 
         let mut pks = HashMap::new();
-        pks.insert("A".to_string(), &authority_a.pk);
-        pks.insert("B".to_string(), &authority_b.pk);
-        pks.insert("C".to_string(), &authority_c.pk);
+        pks.insert("A".to_string(), authority_a.pk.clone());
+        pks.insert("B".to_string(), authority_b.pk.clone());
+        pks.insert("C".to_string(), authority_c.pk.clone());
 
         let ciphertext =
             encrypt(&mut rng, gp, &pks, (policy.to_string(), PolicyLanguage::HumanPolicy), plaintext.as_bytes())


### PR DESCRIPTION
# fix(abe): add Clone derive to several structs for better usability

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


## Description

This pull request introduces the `Clone` derive attribute to several structs within the `abe` module. 