### PR TITLE
feat: add serialization and zeroing for GF256 and Share structs

### DIFF
--- a/crates/tessera-secret-sharing/src/gf256.rs
+++ b/crates/tessera-secret-sharing/src/gf256.rs
@@ -1,7 +1,10 @@
 use std::iter::{Product, Sum};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+#[derive(Default, Copy, Clone, Eq, PartialEq, Debug, Zeroize, Serialize, Deserialize)]
 pub struct GF256(pub u8);
 
 impl GF256 {

--- a/crates/tessera-secret-sharing/src/shamir.rs
+++ b/crates/tessera-secret-sharing/src/shamir.rs
@@ -1,3 +1,6 @@
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
 use crate::gf256::GF256;
 
 pub struct Polynomial {
@@ -21,7 +24,7 @@ impl Polynomial {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize, Serialize, Deserialize)]
 pub struct Share {
     pub x: GF256,
     pub points: Vec<GF256>,


### PR DESCRIPTION
# feat: add serialization and zeroing for GF256 and Share structs

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.



## Description

This pull request introduces serialization and zeroing mechanisms for the GF256 and Share structs. These enhancements are aimed at improving data management and integrity within the system, ensuring that both data is serialized for storage and that it can be securely zeroed when no longer needed.
