### PR TITLE
feat(backbone): impl persisting secret cipher to database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "config",

--- a/crates/tessera-backbone/Cargo.toml
+++ b/crates/tessera-backbone/Cargo.toml
@@ -32,6 +32,7 @@ regex = { workspace = true }
 lazy_static = { workspace = true }
 tessera-abe = { workspace = true }
 rand = { workspace = true }
+base64 = "0.22.1"
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/tessera-backbone/Cargo.toml
+++ b/crates/tessera-backbone/Cargo.toml
@@ -32,7 +32,7 @@ regex = { workspace = true }
 lazy_static = { workspace = true }
 tessera-abe = { workspace = true }
 rand = { workspace = true }
-base64 = "0.22.1"
+base64 = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -154,6 +154,7 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 pub(crate) struct SecretRegisterCommand {
     pub path: String,
     pub key: String,
+    pub cipher: Vec<u8>,
     pub reader_policy_ids: Vec<Ulid>,
     pub writer_policy_ids: Vec<Ulid>,
 }

--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -77,7 +77,9 @@ impl SecretUseCase for SecretUseCaseImpl {
         let reader_policies = self.get_policies(&transaction, cmd.reader_policy_ids).await?;
         let writer_policies = self.get_policies(&transaction, cmd.writer_policy_ids).await?;
 
-        self.secret_service.register(&transaction, cmd.path, cmd.key, reader_policies, writer_policies).await?;
+        self.secret_service
+            .register(&transaction, cmd.path, cmd.key, cmd.cipher, reader_policies, writer_policies)
+            .await?;
 
         transaction.commit().await?;
 
@@ -300,7 +302,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let mut mock_secret_service = MockSecretService::new();
-        mock_secret_service.expect_register().times(1).returning(move |_, _, _, _, _| Ok(()));
+        mock_secret_service.expect_register().times(1).returning(move |_, _, _, _, _, _| Ok(()));
         let mut mock_policy_service = MockPolicyService::new();
         mock_policy_service.expect_get().times(2).returning(move |_, _| {
             Ok(Some(Policy {
@@ -321,6 +323,7 @@ mod test {
             .register(SecretRegisterCommand {
                 path: path.to_owned(),
                 key: key.to_owned(),
+                cipher: vec![],
                 reader_policy_ids,
                 writer_policy_ids,
             })
@@ -355,6 +358,7 @@ mod test {
             .register(SecretRegisterCommand {
                 path: path.to_owned(),
                 key: key.to_owned(),
+                cipher: vec![],
                 reader_policy_ids,
                 writer_policy_ids,
             })

--- a/crates/tessera-backbone/src/database/mod.rs
+++ b/crates/tessera-backbone/src/database/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod parameter;
 pub(crate) mod path;
 pub(crate) mod policy;
 pub(crate) mod secret_metadata;
+pub(crate) mod secret_value;
 pub(crate) mod workspace;
 
 pub(crate) enum AuthMethod {

--- a/crates/tessera-backbone/src/database/secret_value.rs
+++ b/crates/tessera-backbone/src/database/secret_value.rs
@@ -1,0 +1,20 @@
+use chrono::{DateTime, Utc};
+use sea_orm::prelude::*;
+
+use super::UlidId;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "secret_value")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: UlidId,
+    pub identifier: String,
+    pub cipher: Vec<u8>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/tessera-backbone/src/domain/secret/mod.rs
+++ b/crates/tessera-backbone/src/domain/secret/mod.rs
@@ -65,6 +65,7 @@ pub(crate) trait SecretService {
         transaction: &DatabaseTransaction,
         path: String,
         key: String,
+        cipher: Vec<u8>,
         reader_policies: Vec<Policy>,
         writer_policies: Vec<Policy>,
     ) -> Result<()>;
@@ -135,6 +136,7 @@ impl SecretService for PostgresSecretService {
         transaction: &DatabaseTransaction,
         path: String,
         key: String,
+        cipher: Vec<u8>,
         reader_policies: Vec<Policy>,
         writer_policies: Vec<Policy>,
     ) -> Result<()> {
@@ -539,7 +541,7 @@ mod test {
         let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
 
         secret_service
-            .register(&transaction, path.to_owned(), key.to_owned(), reader_policies, writer_policies)
+            .register(&transaction, path.to_owned(), key.to_owned(), vec![], reader_policies, writer_policies)
             .await
             .expect("creating workspace should be successful");
         transaction.commit().await.expect("commiting transaction should be successful");
@@ -571,7 +573,7 @@ mod test {
         let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
 
         let result = secret_service
-            .register(&transaction, path.to_owned(), key.to_owned(), reader_policies, writer_policies)
+            .register(&transaction, path.to_owned(), key.to_owned(), vec![], reader_policies, writer_policies)
             .await;
         transaction.commit().await.expect("commiting transaction should be successful");
 
@@ -608,7 +610,7 @@ mod test {
         let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
 
         let result = secret_service
-            .register(&transaction, path.to_owned(), key.to_owned(), reader_policies, writer_policies)
+            .register(&transaction, path.to_owned(), key.to_owned(), vec![], reader_policies, writer_policies)
             .await;
         transaction.commit().await.expect("commiting transaction should be successful");
 

--- a/crates/tessera-backbone/src/server/router/secret/request.rs
+++ b/crates/tessera-backbone/src/server/router/secret/request.rs
@@ -6,6 +6,7 @@ use ulid::Ulid;
 pub struct PostSecretRequest {
     pub path: String,
     pub key: String,
+    pub cipher: String,
     pub reader_policy_ids: Vec<Ulid>,
     pub writer_policy_ids: Vec<Ulid>,
 }

--- a/crates/tessera-backbone/src/server/router/secret/response/mod.rs
+++ b/crates/tessera-backbone/src/server/router/secret/response/mod.rs
@@ -139,3 +139,12 @@ impl IntoResponse for SecretIdentifierConlictedErrorResponse {
 struct EnteredSecretIdentifierErrorData {
     entered_secret_identifier: String,
 }
+
+pub struct InvalidSecretCipherResponse {}
+
+impl IntoResponse for InvalidSecretCipherResponse {
+    fn into_response(self) -> axum::response::Response {
+        (StatusCode::BAD_REQUEST, error_payload("INVALID_SECRET_CIPHER", "cipher text must be valid base64 text"))
+            .into_response()
+    }
+}


### PR DESCRIPTION
# impl persisting secret cipher to database

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This PR implements a feature that persists cipher text in the database. The implementation assumes a PostgreSQL repository, so additional work is required to support other repositories.

