### PR TITLE
feat(backbone): Response secret with cipher

### DIFF
--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -197,6 +197,7 @@ mod test {
             Ok(vec![SecretEntry {
                 key: key.to_owned(),
                 path: path.to_owned(),
+                cipher: vec![],
                 reader_policy_ids: vec![applied_policy_ids[0].to_owned()],
                 writer_policy_ids: vec![applied_policy_ids[1].to_owned()],
             }])
@@ -267,6 +268,7 @@ mod test {
                 Ok(SecretEntry {
                     key: key.to_owned(),
                     path: path.to_owned(),
+                    cipher: vec![],
                     reader_policy_ids: vec![applied_policy_ids[0].to_owned()],
                     writer_policy_ids: vec![applied_policy_ids[1].to_owned()],
                 })

--- a/crates/tessera-backbone/src/application/secret/mod.rs
+++ b/crates/tessera-backbone/src/application/secret/mod.rs
@@ -90,6 +90,7 @@ impl SecretUseCase for SecretUseCaseImpl {
 pub(crate) struct SecretData {
     pub key: String,
     pub path: String,
+    pub cipher: Vec<u8>,
     pub reader_policy_ids: Vec<Ulid>,
     pub writer_policy_ids: Vec<Ulid>,
 }
@@ -145,6 +146,7 @@ impl From<SecretEntry> for SecretData {
         Self {
             key: value.key,
             path: value.path,
+            cipher: value.cipher,
             reader_policy_ids: value.reader_policy_ids,
             writer_policy_ids: value.writer_policy_ids,
         }
@@ -197,7 +199,7 @@ mod test {
             Ok(vec![SecretEntry {
                 key: key.to_owned(),
                 path: path.to_owned(),
-                cipher: vec![],
+                cipher: vec![4, 5, 6],
                 reader_policy_ids: vec![applied_policy_ids[0].to_owned()],
                 writer_policy_ids: vec![applied_policy_ids[1].to_owned()],
             }])
@@ -215,6 +217,7 @@ mod test {
 
         assert_eq!(result[0].key, key);
         assert_eq!(result[0].path, path);
+        assert_eq!(result[0].cipher, vec![4, 5, 6]);
         assert_eq!(result[0].reader_policy_ids[0], applied_policy_ids[0]);
         assert_eq!(result[0].writer_policy_ids[0], applied_policy_ids[1]);
     }
@@ -268,7 +271,7 @@ mod test {
                 Ok(SecretEntry {
                     key: key.to_owned(),
                     path: path.to_owned(),
-                    cipher: vec![],
+                    cipher: vec![4, 5, 6],
                     reader_policy_ids: vec![applied_policy_ids[0].to_owned()],
                     writer_policy_ids: vec![applied_policy_ids[1].to_owned()],
                 })
@@ -287,6 +290,7 @@ mod test {
 
         assert_eq!(result.key, key);
         assert_eq!(result.path, path);
+        assert_eq!(result.cipher, vec![4, 5, 6]);
         assert_eq!(result.reader_policy_ids[0], applied_policy_ids[0]);
         assert_eq!(result.writer_policy_ids[0], applied_policy_ids[1]);
     }
@@ -325,7 +329,7 @@ mod test {
             .register(SecretRegisterCommand {
                 path: path.to_owned(),
                 key: key.to_owned(),
-                cipher: vec![],
+                cipher: vec![4, 5, 6],
                 reader_policy_ids,
                 writer_policy_ids,
             })

--- a/crates/tessera-backbone/src/domain/secret/mod.rs
+++ b/crates/tessera-backbone/src/domain/secret/mod.rs
@@ -310,7 +310,7 @@ mod test {
             .append_query_results([vec![secret_value::Model {
                 id: UlidId::new(Ulid::new()),
                 identifier: "/test/path/TEST_KEY".to_owned(),
-                cipher: vec![],
+                cipher: vec![1, 2, 3],
                 created_at: now,
                 updated_at: now,
             }]]);
@@ -326,6 +326,7 @@ mod test {
 
         assert_eq!(result[0].key, key);
         assert_eq!(result[0].path, path);
+        assert_eq!(result[0].cipher, vec![1, 2, 3]);
         assert_eq!(result[0].reader_policy_ids[0], Ulid::from_str("01JACZ44MJDY5GD21X2W910CFV").unwrap());
         assert_eq!(result[0].writer_policy_ids[0], Ulid::from_str("01JACZ44MJDY5GD21X2W910CFV").unwrap());
     }
@@ -389,7 +390,7 @@ mod test {
             .append_query_results([vec![secret_value::Model {
                 id: UlidId::new(Ulid::new()),
                 identifier: "/test/path/TEST_KEY".to_owned(),
-                cipher: vec![],
+                cipher: vec![1, 2, 3],
                 created_at: now,
                 updated_at: now,
             }]]);
@@ -406,6 +407,7 @@ mod test {
 
         assert_eq!(result.key, key);
         assert_eq!(result.path, path);
+        assert_eq!(result.cipher, vec![1, 2, 3]);
         assert_eq!(result.reader_policy_ids[0], Ulid::from_str("01JACZ44MJDY5GD21X2W910CFV").unwrap());
         assert_eq!(result.writer_policy_ids[0], Ulid::from_str("01JACZ44MJDY5GD21X2W910CFV").unwrap());
     }
@@ -591,7 +593,7 @@ mod test {
             .append_query_results([vec![secret_value::Model {
                 id: UlidId::new(Ulid::new()),
                 identifier: "/test/path/TEST_KEY".to_owned(),
-                cipher: vec![],
+                cipher: vec![1, 2, 3],
                 created_at: now,
                 updated_at: now,
             }]]);
@@ -603,7 +605,7 @@ mod test {
         let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
 
         secret_service
-            .register(&transaction, path.to_owned(), key.to_owned(), vec![], reader_policies, writer_policies)
+            .register(&transaction, path.to_owned(), key.to_owned(), vec![1, 2, 3], reader_policies, writer_policies)
             .await
             .expect("creating workspace should be successful");
         transaction.commit().await.expect("commiting transaction should be successful");

--- a/crates/tessera-backbone/src/domain/secret/mod.rs
+++ b/crates/tessera-backbone/src/domain/secret/mod.rs
@@ -123,7 +123,7 @@ impl SecretService for PostgresSecretService {
             .into_iter()
             .zip(applied_policies.into_iter())
             .map(|(metadata, applied_policies)| {
-                let cipher = ciphers.remove(&create_identifier(&metadata.path, &metadata.key)).unwrap_or_else(Vec::new);
+                let cipher = ciphers.remove(&create_identifier(&metadata.path, &metadata.key)).unwrap_or_default();
 
                 SecretEntry::from((metadata, applied_policies, cipher))
             })
@@ -149,7 +149,7 @@ impl SecretService for PostgresSecretService {
             .one(transaction)
             .await?
             .map(|secret_value| secret_value.cipher)
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         Ok(SecretEntry::from((metadata, applied_policies, cipher)))
     }

--- a/crates/tessera-backbone/src/server/router/secret/mod.rs
+++ b/crates/tessera-backbone/src/server/router/secret/mod.rs
@@ -93,6 +93,7 @@ impl From<SecretData> for SecretResponse {
         Self {
             key: value.key,
             path: value.path,
+            cipher: BASE64_STANDARD.encode(value.cipher),
             reader_policy_ids: value.reader_policy_ids,
             writer_policy_ids: value.writer_policy_ids,
         }

--- a/crates/tessera-backbone/src/server/router/secret/response/mod.rs
+++ b/crates/tessera-backbone/src/server/router/secret/response/mod.rs
@@ -64,6 +64,7 @@ struct EnteredIdentifierErrorData {
 pub(super) struct SecretResponse {
     pub key: String,
     pub path: String,
+    pub cipher: String,
     pub reader_policy_ids: Vec<Ulid>,
     pub writer_policy_ids: Vec<Ulid>,
 }


### PR DESCRIPTION
# Response secret with cipher

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This PR implements a feature that functionality to include the cipher text when responding secret data. The implementation assumes a PostgreSQL repository, so additional work is required to support other repositories.
