### PR TITLE
refactor(backbone): switch serialization from serde_json to rmp_serde for global parameter

### DIFF
--- a/crates/tessera-backbone/src/database/parameter.rs
+++ b/crates/tessera-backbone/src/database/parameter.rs
@@ -9,7 +9,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: UlidId,
     pub version: i32,
-    pub value: Json,
+    pub value: Vec<u8>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }


### PR DESCRIPTION
# refactor(backbone): switch serialization from serde_json to rmp_serde for global parameter

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->



## Description

This pull request refactors the serialization method used for the global parameter in the Backbone module. The previous serialization approach using `serde_json` has been replaced with `rmp_serde`


