### PR TITLE
feat(authority): Add getting the public key endpoint

### DIFF
--- a/crates/tessera-authority/src/domain/authority.rs
+++ b/crates/tessera-authority/src/domain/authority.rs
@@ -52,6 +52,18 @@ impl Authority {
         Ok(key_pair)
     }
 
+    pub async fn key_pair_by_version(&self, version: u64) -> Result<KeyPair> {
+        let name = &self.name;
+        let key_pair = match self.key_pair_service.key_pair_by_version(name, version).await? {
+            Some(key_pair) => key_pair,
+            None => {
+                return Err(anyhow::anyhow!("Key pair with version {} not found", version));
+            }
+        };
+
+        Ok(key_pair)
+    }
+
     pub async fn init_key_pair_storage(&self, share: usize, threshold: usize) -> Result<Zeroizing<Vec<Share>>> {
         self.key_pair_service.shield_initialize(share, threshold).await
     }

--- a/crates/tessera-authority/src/domain/key_pair.rs
+++ b/crates/tessera-authority/src/domain/key_pair.rs
@@ -124,6 +124,8 @@ impl ShieldedKeyPairService for FileKeyPairService<'_> {
         let master_key = self.storage.generate_key().await?;
         let shares = Zeroizing::new(split(&master_key, share, threshold));
         self.storage.initialize(&master_key).await?;
+
+        self.storage.disarm(&master_key).await?; // Disarm the storage immediately after initialization
         Ok(shares)
     }
 

--- a/crates/tessera-authority/src/server/mod.rs
+++ b/crates/tessera-authority/src/server/mod.rs
@@ -19,7 +19,10 @@ impl From<ApplicationConfig> for ServerConfig {
 
 pub(super) async fn run(application: Application, config: ServerConfig) -> anyhow::Result<()> {
     let application = Arc::new(application);
-    let app = Router::new().route("/health", get(|| async { "OK" })).nest("/v1", router::init::router(application));
+    let app = Router::new()
+        .route("/health", get(|| async { "OK" }))
+        .nest("/v1", router::init::router(application.clone()))
+        .nest("/v1", router::pubkey::router(application.clone()));
 
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", config.port)).await?;
     debug!("starting authority server on {}", config.port);

--- a/crates/tessera-authority/src/server/router/init/mod.rs
+++ b/crates/tessera-authority/src/server/router/init/mod.rs
@@ -20,18 +20,18 @@ async fn handle_initializing_authority(
         .authority
         .init_key_pair_storage(share as usize, threshold as usize)
         .await
-        .inspect_err(|e| eprintln!("Error initializing authority key pair: {}", e))
-        .map_err(|_| InitAuthorityError::InitializationError)?;
+        .map_err(|_| InitAuthorityError::KeyPairInitialization)?;
     let shares = shares
         .iter()
         .map(|share| rmp_serde::to_vec(&share))
         .collect::<Result<Vec<_>, _>>()
-        .map_err(InitAuthorityError::SerializationError)?;
+        .map_err(InitAuthorityError::Serialization)?;
     let shares = shares.iter().map(|share| STANDARD.encode(share)).collect::<Vec<_>>();
     Ok(Json(shares))
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InitRequest {
     secret_shares: u8,
     secret_threshold: u8,
@@ -41,9 +41,9 @@ pub struct InitRequest {
 pub enum InitAuthorityError {
     #[error("Unable to initialize the authority key pair")]
     #[status(StatusCode::INTERNAL_SERVER_ERROR)]
-    InitializationError,
+    KeyPairInitialization,
 
     #[error("Unable to serialize the shares")]
     #[status(StatusCode::INTERNAL_SERVER_ERROR)]
-    SerializationError(#[from] rmp_serde::encode::Error),
+    Serialization(#[from] rmp_serde::encode::Error),
 }

--- a/crates/tessera-authority/src/server/router/mod.rs
+++ b/crates/tessera-authority/src/server/router/mod.rs
@@ -1,1 +1,2 @@
 pub mod init;
+pub mod pubkey;

--- a/crates/tessera-authority/src/server/router/pubkey/mod.rs
+++ b/crates/tessera-authority/src/server/router/pubkey/mod.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use axum_thiserror::ErrorStatus;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::application::Application;
+
+pub(crate) fn router(application: Arc<Application>) -> axum::Router {
+    Router::new().route("/public-key", get(handle_get_public_key)).with_state(application)
+}
+
+async fn handle_get_public_key(
+    Query(query_params): Query<GetPublicKeyQueryParam>,
+    State(application): State<Arc<Application>>,
+) -> Result<impl IntoResponse, GetPublicKeyError> {
+    let key_pair = if let Some(version) = query_params.version {
+        application.authority.key_pair_by_version(version).await
+    } else {
+        application.authority.key_pair().await
+    }
+    .map_err(|_| GetPublicKeyError::GetPublicKey)?;
+
+    let public_key = rmp_serde::to_vec(&key_pair.pk).map_err(GetPublicKeyError::Serialization)?;
+    let public_key = STANDARD.encode(&public_key);
+
+    Ok(Json(GetPublicKeyResponse { public_key }))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct GetPublicKeyQueryParam {
+    version: Option<u64>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetPublicKeyResponse {
+    public_key: String,
+}
+
+#[derive(Error, Debug, ErrorStatus)]
+pub enum GetPublicKeyError {
+    #[error("Unable to get the public key")]
+    #[status(StatusCode::INTERNAL_SERVER_ERROR)]
+    GetPublicKey,
+
+    #[error("Unable to serialize the public key")]
+    #[status(StatusCode::INTERNAL_SERVER_ERROR)]
+    Serialization(#[from] rmp_serde::encode::Error),
+}


### PR DESCRIPTION
# feat(authority): Add getting the public key endpoint

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This PR introduces an endpoint for retrieving the public key, enhancing the authority module's capabilities. It also includes improvements to error handling for authority initialization, ensuring more robust and clear interactions. Additionally, recent changes have refined the method for retrieving key pairs by version, and adjusted parameter types for enhanced decoding in the BackboneClient.

### BREAKING CHANGE

In commit [48cc518](https://github.com/CremitHQ/tessera/pull/68/commits/48cc5183f5b120d696ac6d1eb73416484c0dcbc5), I implemented the initialization of KeyPair storage followed immediately by the disarm process. This approach deviates from conventional methods, such as HashiCorp Vault’s initialization process, which requires unsealing before accessing the physical backend. While this design enhances convenience, it's important to evaluate any potential security implications. My assessment is that the authority component handles minimal sensitive data, so adopting this process could improve the user experience without significant security risks. I would appreciate any feedback on this PR