### PR TITLE
refactor: improve clarity for error handling and validation

### DIFF
--- a/crates/tessera-abe/src/utils/secret_shares.rs
+++ b/crates/tessera-abe/src/utils/secret_shares.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::curves::{Field, PairingCurve, RefAdd as _, RefMul as _, RefNeg as _, RefPow as _, RefSub as _};
-use crate::error::ABEError;
+use crate::error::{ABEError, InvalidPolicyErrorKind};
 use crate::random::Random;
 use crate::utils::tools::{contains, get_value};
 use tessera_policy::pest::{PolicyType, PolicyValue};
@@ -131,11 +131,11 @@ pub fn gen_shares<T: PairingCurve>(rng: &mut T::Rng, secret: &T::Field, k: usize
     shares
 }
 
-pub fn calc_pruned<'a>(
+pub fn calc_pruned(
     attr: &Vec<String>,
     policy_value: &PolicyValue,
     policy_type: Option<PolicyType>,
-) -> Result<(bool, Vec<(String, String)>), ABEError<'a>> {
+) -> Result<(bool, Vec<(String, String)>), ABEError> {
     let mut matched_nodes: Vec<(String, String)> = vec![];
     match policy_value {
         PolicyValue::Object(obj) => match obj.0 {
@@ -157,7 +157,7 @@ pub fn calc_pruned<'a>(
                             }
                         }
                     } else {
-                        return Err(ABEError::InvalidPolicy("AND with just a single child.".into()));
+                        return Err(ABEError::InvalidPolicy(InvalidPolicyErrorKind::ANDWithSingleChild));
                     }
                     if !policy_match {
                         matched_nodes = vec![];
@@ -177,10 +177,10 @@ pub fn calc_pruned<'a>(
                         }
                         Ok((policy_match, matched_nodes))
                     } else {
-                        Err(ABEError::InvalidPolicy("OR with just a single child.".into()))
+                        Err(ABEError::InvalidPolicy(InvalidPolicyErrorKind::ORWithSingleChild))
                     }
                 }
-                _ => Err(ABEError::InvalidPolicy("unknown array type!".into())),
+                _ => Err(ABEError::InvalidPolicy(InvalidPolicyErrorKind::UnexpectedArrayType)),
             }
         }
         PolicyValue::String(node) => {

--- a/crates/tessera-policy/src/error.rs
+++ b/crates/tessera-policy/src/error.rs
@@ -5,33 +5,33 @@ use std::cmp;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum PolicyError {
-    #[error("Json Policy Error: {0}")]
+pub enum PolicyParserError {
+    #[error("json policy error: {0}")]
     JsonPolicy(String),
-    #[error("Human Policy Error: {0}")]
+    #[error("human policy error: {0}")]
     HumanPolicy(String),
-    #[error("Empty Policy Error")]
+    #[error("provided policy was empty")]
     Empty,
-    #[error("Invalid Policy Type")]
+    #[error("invalid policy type")]
     InvalidPolicyType,
 }
 
-impl From<PestError<JsonRule>> for PolicyError {
+impl From<PestError<JsonRule>> for PolicyParserError {
     fn from(error: PestError<JsonRule>) -> Self {
         let line = match error.line_col.to_owned() {
             LineColLocation::Pos((line, _)) => line,
             LineColLocation::Span((start_line, _), (end_line, _)) => cmp::max(start_line, end_line),
         };
-        PolicyError::JsonPolicy(format!("Json Policy Error in line {}\n", line))
+        PolicyParserError::JsonPolicy(format!("Json Policy Error in line {}\n", line))
     }
 }
 
-impl From<PestError<HumanRule>> for PolicyError {
+impl From<PestError<HumanRule>> for PolicyParserError {
     fn from(error: PestError<HumanRule>) -> Self {
         let line = match error.line_col.to_owned() {
             LineColLocation::Pos((line, _)) => line,
             LineColLocation::Span((start_line, _), (end_line, _)) => cmp::max(start_line, end_line),
         };
-        PolicyError::HumanPolicy(format!("Human Policy Error in line {}\n", line))
+        PolicyParserError::HumanPolicy(format!("Human Policy Error in line {}\n", line))
     }
 }

--- a/crates/tessera-policy/src/pest/human.rs
+++ b/crates/tessera-policy/src/pest/human.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::PolicyError,
+    error::PolicyParserError,
     pest::{PolicyType, PolicyValue},
 };
 use pest::iterators::Pair;
@@ -8,7 +8,7 @@ use pest::iterators::Pair;
 #[grammar = "human.policy.pest"]
 pub(crate) struct HumanPolicyParser;
 
-pub(crate) fn parse(pair: Pair<Rule>) -> Result<PolicyValue, PolicyError> {
+pub(crate) fn parse(pair: Pair<Rule>) -> Result<PolicyValue, PolicyParserError> {
     match pair.as_rule() {
         Rule::string | Rule::number => {
             let p = pair.into_inner().next().unwrap();
@@ -43,6 +43,6 @@ pub(crate) fn parse(pair: Pair<Rule>) -> Result<PolicyValue, PolicyError> {
         | Rule::BRACEOPEN
         | Rule::BRACECLOSE
         | Rule::QUOTE
-        | Rule::WHITESPACE => Err(PolicyError::InvalidPolicyType),
+        | Rule::WHITESPACE => Err(PolicyParserError::InvalidPolicyType),
     }
 }

--- a/crates/tessera-policy/src/pest/json.rs
+++ b/crates/tessera-policy/src/pest/json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::PolicyError,
+    error::PolicyParserError,
     pest::{PolicyType, PolicyValue},
 };
 use pest::iterators::Pair;
@@ -8,7 +8,7 @@ use pest::iterators::Pair;
 #[grammar = "json.policy.pest"]
 pub(crate) struct JSONPolicyParser;
 
-pub(crate) fn parse(pair: Pair<Rule>) -> Result<PolicyValue, PolicyError> {
+pub(crate) fn parse(pair: Pair<Rule>) -> Result<PolicyValue, PolicyParserError> {
     match pair.as_rule() {
         Rule::string | Rule::number => {
             let p = pair.into_inner().next().unwrap();
@@ -42,6 +42,6 @@ pub(crate) fn parse(pair: Pair<Rule>) -> Result<PolicyValue, PolicyError> {
         | Rule::CHILDREN
         | Rule::COMMENT
         | Rule::QUOTE
-        | Rule::WHITESPACE => Err(PolicyError::InvalidPolicyType),
+        | Rule::WHITESPACE => Err(PolicyParserError::InvalidPolicyType),
     }
 }

--- a/crates/tessera-policy/src/pest/mod.rs
+++ b/crates/tessera-policy/src/pest/mod.rs
@@ -1,6 +1,6 @@
 use self::human::HumanPolicyParser;
 use self::json::JSONPolicyParser;
-use crate::error::PolicyError;
+use crate::error::PolicyParserError;
 use pest::Parser;
 use serde::{Deserialize, Serialize};
 use std::string::String;
@@ -32,18 +32,18 @@ pub enum PolicyValue<'a> {
 }
 
 /// Parses a &str in a give [PolicyLanguage] to a PolicyValue tree
-pub fn parse(policy: &str, language: PolicyLanguage) -> Result<PolicyValue, PolicyError> {
+pub fn parse(policy: &str, language: PolicyLanguage) -> Result<PolicyValue, PolicyParserError> {
     match language {
         PolicyLanguage::JsonPolicy => {
             use crate::pest::json::Rule;
             let mut result = JSONPolicyParser::parse(Rule::content, policy)?;
-            let result = result.next().ok_or(PolicyError::Empty)?;
+            let result = result.next().ok_or(PolicyParserError::Empty)?;
             json::parse(result)
         }
         PolicyLanguage::HumanPolicy => {
             use crate::pest::human::Rule;
             let mut result = HumanPolicyParser::parse(Rule::content, policy)?;
-            let result = result.next().ok_or(PolicyError::Empty)?;
+            let result = result.next().ok_or(PolicyParserError::Empty)?;
             human::parse(result)
         }
     }

--- a/crates/tessera-storage/src/shield/aes.rs
+++ b/crates/tessera-storage/src/shield/aes.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 use super::Shield;
 use crate::Storage;
@@ -51,60 +48,66 @@ impl DerefMut for ZeroizingKey {
 }
 
 #[derive(Error, Debug)]
-pub enum AESShieldError<'a> {
-    #[error("Key generation error: {0}")]
-    KeyGenerationError(#[from] KeyGenerationError),
+pub enum AESShieldError {
+    #[error("error while generating shield key: {0}")]
+    GenerateKey(#[from] GenerateKeyErrorKind),
 
-    #[error("Initialization error: {0}")]
-    InitializationError(#[from] InitializationError),
+    #[error("error while initializing shield key: {0}")]
+    InitializeShieldKey(#[from] InitializationErrorKind),
 
-    #[error(transparent)]
-    StorageError(AESShieldStorageError<'a>),
+    #[error("error while disarming shield key: {0}")]
+    DisarmShieldKey(#[from] DisarmErrorKind),
 
-    #[error("There is no shield key. Please initialize the shield first.")]
+    #[error("shield storage error: {0}")]
+    StorageError(#[from] AESShieldStorageError),
+
+    #[error("no shield key")]
     NoShieldKey,
-
-    #[error("AES GCM error: {0}")]
-    AESGCMError(#[from] AESGCMError),
 }
 
 #[derive(Error, Debug)]
-pub enum AESShieldStorageError<'a> {
-    #[error("Shield has been armored. Cannot perform operation.")]
-    ShieldArmored,
+pub enum InitializationErrorKind {
+    #[error("invalid key size (expected: {0} bytes, got: {1} bytes)")]
+    InvalidKeySize(usize, usize),
 
-    #[error("Storage error: {0}")]
-    StorageError(Cow<'a, str>),
+    #[error("failed to serialize shield key ({0})")]
+    SerializeShieldKey(#[from] rmp_serde::encode::Error),
+
+    #[error("failed to deserialize shield key ({0})")]
+    DeserializeShieldKey(#[from] rmp_serde::decode::Error),
 
     #[error(transparent)]
-    AESGCMError(#[from] AESGCMError),
+    AESGCMError(#[from] AESGCMErrorKind),
+
+    #[error("failed to read shield key ({0})")]
+    ReadShieldKey(String),
+
+    #[error("failed to write shield key ({0})")]
+    WriteShieldKey(String),
 }
 
 #[derive(Error, Debug)]
-pub enum InitializationError {
-    #[error("Invalid key size: {0}")]
-    InvalidKeySize(usize),
+pub enum DisarmErrorKind {
+    #[error(transparent)]
+    AESGCMError(#[from] AESGCMErrorKind),
 
-    #[error("Failed to serialize shield key: {0}")]
-    SerializationError(#[from] rmp_serde::encode::Error),
-
-    #[error("Failed to deserialize shield key: {0}")]
-    DeserializationError(#[from] rmp_serde::decode::Error),
+    #[error("failed to read shield key ({0})")]
+    ReadShieldKey(String),
 }
 
 #[derive(Error, Debug)]
-pub enum KeyGenerationError {
-    #[error("Failed to fill random data: {0}")]
-    FillRandomDataError(#[from] rand::Error),
+pub enum GenerateKeyErrorKind {
+    #[error("failed to fill random data ({0})")]
+    FillRandomData(#[from] rand::Error),
 }
 
 #[derive(Error, Debug)]
-pub enum AESGCMError {
-    #[error("Encryption error: {0}")]
-    EncryptionError(aes_gcm::Error),
+pub enum AESGCMErrorKind {
+    #[error("encryption error ({0})")]
+    Encryption(aes_gcm::Error),
 
-    #[error("Decryption error: {0}")]
-    DecryptionError(aes_gcm::Error),
+    #[error("decryption error ({0})")]
+    Decryption(aes_gcm::Error),
 }
 
 impl<S: Storage> AESShieldStorage<S> {
@@ -114,17 +117,13 @@ impl<S: Storage> AESShieldStorage<S> {
 }
 
 impl<S: Storage<Key = str, Value = [u8]>> Shield for AESShieldStorage<S> {
-    type ShieldError<'e> = AESShieldError<'e>;
+    type ShieldError = AESShieldError;
     type Key = <S as Storage>::Value;
     type ZeroizingKey = ZeroizingKey;
 
-    async fn initialize<'a>(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError<'a>> {
-        let shield_key = self
-            .inner
-            .get(SHIELD_KEY_PATH)
-            .await
-            .map_err(|e| AESShieldStorageError::StorageError(e.to_string().into()))
-            .map_err(AESShieldError::StorageError)?;
+    async fn initialize(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError> {
+        let shield_key =
+            self.inner.get(SHIELD_KEY_PATH).await.map_err(|e| InitializationErrorKind::ReadShieldKey(e.to_string()))?;
 
         // If shield_key is already set in the storage, we return `Ok(())` to maintain idempotency.
         // This is intentional—no need to throw an error here.
@@ -134,29 +133,28 @@ impl<S: Storage<Key = str, Value = [u8]>> Shield for AESShieldStorage<S> {
 
         let key_size = master_key.len();
         if key_size != AES_BLOCK_SIZE {
-            return Err(InitializationError::InvalidKeySize(key_size).into());
+            return Err(InitializationErrorKind::InvalidKeySize(AES_BLOCK_SIZE, key_size).into());
         }
         let storage_key = self.generate_key().await?;
         let shield_key = AESShieldKey { version: AES_GCM_VERSION, key: storage_key };
-        let shield_key = rmp_serde::to_vec(&shield_key).map_err(InitializationError::SerializationError)?;
-        let shield_key = self.encrypt(master_key, &shield_key)?;
+        let shield_key = rmp_serde::to_vec(&shield_key).map_err(InitializationErrorKind::SerializeShieldKey)?;
+        let shield_key = self.encrypt(master_key, &shield_key).map_err(InitializationErrorKind::AESGCMError)?;
         self.inner
             .set(SHIELD_KEY_PATH, &shield_key)
             .await
-            .map_err(|e| AESShieldStorageError::StorageError(e.to_string().into()))
-            .map_err(AESShieldError::StorageError)?;
+            .map_err(|e| InitializationErrorKind::WriteShieldKey(e.to_string()))?;
 
         Ok(())
     }
 
-    async fn armor<'a>(&self) -> Result<(), Self::ShieldError<'a>> {
+    async fn armor(&self) -> Result<(), Self::ShieldError> {
         let mut shield_key = self.shield_key.write().await;
         let shield_key = shield_key.deref_mut();
         *shield_key = None;
         Ok(())
     }
 
-    async fn disarm<'a>(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError<'a>> {
+    async fn disarm(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError> {
         if !self.is_armored().await {
             return Ok(());
         }
@@ -165,14 +163,14 @@ impl<S: Storage<Key = str, Value = [u8]>> Shield for AESShieldStorage<S> {
             .inner
             .get(SHIELD_KEY_PATH)
             .await
-            .map_err(|e| AESShieldStorageError::StorageError(e.to_string().into()))
-            .map_err(AESShieldError::StorageError)?
+            .map_err(|e| DisarmErrorKind::ReadShieldKey(e.to_string()))?
             .ok_or(AESShieldError::NoShieldKey)?;
 
         // We manually zeroize `shield_key` to make sure it doesn't linger in memory.
-        let shield_key = ZeroizingKey::new(self.decrypt(master_key, &armored_shield_key)?);
+        let shield_key =
+            ZeroizingKey::new(self.decrypt(master_key, &armored_shield_key).map_err(DisarmErrorKind::AESGCMError)?);
         let shield_key: AESShieldKey =
-            rmp_serde::from_slice(&shield_key).map_err(InitializationError::DeserializationError)?;
+            rmp_serde::from_slice(&shield_key).map_err(InitializationErrorKind::DeserializeShieldKey)?;
 
         let mut shield = self.shield_key.write().await;
         let shield = shield.deref_mut();
@@ -181,7 +179,7 @@ impl<S: Storage<Key = str, Value = [u8]>> Shield for AESShieldStorage<S> {
         Ok(())
     }
 
-    async fn generate_key<'a>(&self) -> Result<ZeroizingKey, Self::ShieldError<'a>> {
+    async fn generate_key(&self) -> Result<ZeroizingKey, Self::ShieldError> {
         let mut buf = vec![0; AES_BLOCK_SIZE];
         OsRng.fill(buf.deref_mut());
         Ok(ZeroizingKey::new(buf))
@@ -193,7 +191,7 @@ impl<S: Storage> AESShieldStorage<S> {
         self.shield_key.read().await.is_none()
     }
 
-    fn encrypt(&self, key: &[u8], data: &[u8]) -> Result<Vec<u8>, AESGCMError> {
+    fn encrypt(&self, key: &[u8], data: &[u8]) -> Result<Vec<u8>, AESGCMErrorKind> {
         debug_assert!(key.len() == AES_BLOCK_SIZE);
         let key = Key::<Aes256Gcm>::from_slice(key);
         let cipher = Aes256Gcm::new(key);
@@ -201,27 +199,25 @@ impl<S: Storage> AESShieldStorage<S> {
         OsRng.fill(&mut nonce_vec);
 
         let nonce = Nonce::from_slice(nonce_vec.as_ref());
-        let mut ct = cipher.encrypt(nonce, data.as_ref()).map_err(AESGCMError::EncryptionError)?;
+        let mut ct = cipher.encrypt(nonce, data.as_ref()).map_err(AESGCMErrorKind::Encryption)?;
         ct.splice(0..0, nonce.iter().cloned()); // first 12 bytes are nonce i.e. [nonce|ciphertext]
         Ok(ct)
     }
 
-    fn decrypt(&self, key: &[u8], data: &[u8]) -> Result<Vec<u8>, AESGCMError> {
+    fn decrypt(&self, key: &[u8], data: &[u8]) -> Result<Vec<u8>, AESGCMErrorKind> {
         debug_assert!(key.len() == AES_BLOCK_SIZE);
         let nonce = data[..12].as_ref();
         let ciphertext = data.to_vec().split_off(12);
         let key = Key::<Aes256Gcm>::from_slice(key);
         let cipher = Aes256Gcm::new(key);
         let nonce = Nonce::from_slice(nonce);
-        let result = cipher.decrypt(nonce, ciphertext.as_ref()).map_err(AESGCMError::DecryptionError)?;
+        let result = cipher.decrypt(nonce, ciphertext.as_ref()).map_err(AESGCMErrorKind::Decryption)?;
         Ok(result)
     }
 }
 
 impl<S: Storage<Key = str, Value = [u8]>> Storage for AESShieldStorage<S> {
-    // TODO: GATs would be nice here, but we can't use them
-    // because of the known limitation (https://github.com/rust-lang/rust/issues/100013)
-    type StorageError = AESShieldStorageError<'static>;
+    type StorageError = AESShieldStorageError;
     type Key = <S as Storage>::Key;
     type Value = <S as Storage>::Value;
 
@@ -232,8 +228,7 @@ impl<S: Storage<Key = str, Value = [u8]>> Storage for AESShieldStorage<S> {
         let shield_key = self.shield_key.read().await;
         let shield_key = shield_key.as_ref().unwrap(); // Since we've already validated this earlier with is_armored(), it's safe to use unwrap() here.
         debug_assert!(shield_key.key.len() == AES_BLOCK_SIZE);
-        let ciphertext =
-            self.inner.get(key).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string().into()))?;
+        let ciphertext = self.inner.get(key).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string()))?;
 
         match ciphertext {
             Some(ciphertext) => {
@@ -252,7 +247,7 @@ impl<S: Storage<Key = str, Value = [u8]>> Storage for AESShieldStorage<S> {
         let shield_key = shield_key.as_ref().unwrap(); // Since we've already validated this earlier with is_armored(), it's safe to use unwrap() here.
         debug_assert!(shield_key.key.len() == AES_BLOCK_SIZE);
         let ciphertext = self.encrypt(&shield_key.key, value)?;
-        self.inner.set(key, &ciphertext).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string().into()))
+        self.inner.set(key, &ciphertext).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string()))
     }
 
     async fn delete(&self, key: &str) -> Result<(), Self::StorageError> {
@@ -260,7 +255,7 @@ impl<S: Storage<Key = str, Value = [u8]>> Storage for AESShieldStorage<S> {
             return Err(AESShieldStorageError::ShieldArmored);
         }
 
-        self.inner.delete(key).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string().into()))
+        self.inner.delete(key).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string()))
     }
 
     async fn list(&self, prefix: &str) -> Result<impl IntoIterator<Item = String>, Self::StorageError> {
@@ -268,6 +263,18 @@ impl<S: Storage<Key = str, Value = [u8]>> Storage for AESShieldStorage<S> {
             return Err(AESShieldStorageError::ShieldArmored);
         }
 
-        self.inner.list(prefix).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string().into()))
+        self.inner.list(prefix).await.map_err(|e| AESShieldStorageError::StorageError(e.to_string()))
     }
+}
+
+#[derive(Error, Debug)]
+pub enum AESShieldStorageError {
+    #[error("shield has already been armored")]
+    ShieldArmored,
+
+    #[error("storage error occurred ({0})")]
+    StorageError(String),
+
+    #[error(transparent)]
+    AESGCMError(#[from] AESGCMErrorKind),
 }

--- a/crates/tessera-storage/src/shield/mod.rs
+++ b/crates/tessera-storage/src/shield/mod.rs
@@ -4,11 +4,11 @@ pub mod aes;
 
 #[trait_variant::make(Shield: Send)]
 pub trait LocalShield {
-    type ShieldError<'error>: std::error::Error;
+    type ShieldError: std::error::Error;
     type Key: ToOwned + ?Sized;
     type ZeroizingKey: ZeroizeOnDrop;
-    async fn initialize<'a>(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError<'a>>;
-    async fn armor<'a>(&self) -> Result<(), Self::ShieldError<'a>>;
-    async fn disarm<'a>(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError<'a>>;
-    async fn generate_key<'a>(&self) -> Result<Self::ZeroizingKey, Self::ShieldError<'a>>;
+    async fn initialize(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError>;
+    async fn armor(&self) -> Result<(), Self::ShieldError>;
+    async fn disarm(&self, master_key: &Self::Key) -> Result<(), Self::ShieldError>;
+    async fn generate_key(&self) -> Result<Self::ZeroizingKey, Self::ShieldError>;
 }


### PR DESCRIPTION
# refactor-policy-error-handling

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->



## Description

This pull request refactors the error handling in the policy system to improve clarity and type safety. Key changes include:
- Streamlining error handling and type definitions in the storage module.
- Renaming `PolicyError` to `PolicyParserError` to better reflect its purpose, along with modifications to the error details.
- Replacing error details with more consistent error types in the ABE module.
- Implementing key validation to prevent the usage of ".." in storage paths.

This refactor aims to enhance maintainability and reduce potential bugs related to error handling.

## Acknowledgement
https://rust-lang.github.io/api-guidelines/interoperability.html?highlight=message#error-types-are-meaningful-and-well-behaved-c-good-err
https://rust-lang.github.io/api-guidelines/naming.html#names-use-a-consistent-word-order-c-word-order
