### PR TITLE
refactor(policy): policy tree nodes to construct with a b-tree

### DIFF
--- a/crates/tessera-abe/src/error.rs
+++ b/crates/tessera-abe/src/error.rs
@@ -20,15 +20,6 @@ pub enum InvalidPolicyErrorKind {
 
     #[error(transparent)]
     ParsePolicy(#[from] PolicyParserError),
-
-    #[error("`AND` with just a single child")]
-    ANDWithSingleChild,
-
-    #[error("`OR` with just a single child.")]
-    ORWithSingleChild,
-
-    #[error("array type should be `AND` or `OR`")]
-    UnexpectedArrayType,
 }
 
 #[derive(Error, Debug)]

--- a/crates/tessera-abe/src/utils/tools.rs
+++ b/crates/tessera-abe/src/utils/tools.rs
@@ -1,6 +1,6 @@
 use crate::utils::secret_shares::node_index;
 use std::collections::HashSet;
-use tessera_policy::pest::{PolicyType, PolicyValue};
+use tessera_policy::pest::PolicyNode;
 
 pub fn is_negative(attr: &str) -> bool {
     let first_char = &attr[..1];
@@ -12,50 +12,15 @@ pub fn contains(data: &[String], value: &str) -> bool {
     return data.iter().any(|x| x == value);
 }
 
-// used to check if a set of attributes is a subset of another
 pub fn is_subset(subset: &[&str], attr: &[&str]) -> bool {
     let super_set: HashSet<_> = attr.iter().cloned().collect();
     let sub_set: HashSet<_> = subset.iter().cloned().collect();
     sub_set.is_subset(&super_set)
 }
 
-// used to traverse / check policy tree
-pub fn traverse_policy(attr: &[String], policy_value: &PolicyValue, policy_type: PolicyType) -> bool {
-    return (!attr.is_empty())
-        && match policy_value {
-            PolicyValue::String(node) => attr.iter().any(|x| x == node.0),
-            PolicyValue::Object(obj) => {
-                return match obj.0 {
-                    PolicyType::And => traverse_policy(attr, obj.1.as_ref(), PolicyType::And),
-                    PolicyType::Or => traverse_policy(attr, obj.1.as_ref(), PolicyType::Or),
-                    _ => true,
-                }
-            }
-            PolicyValue::Array(arrayref) => {
-                return match policy_type {
-                    PolicyType::And => {
-                        let mut ret = true;
-                        for obj in arrayref.iter() {
-                            ret &= traverse_policy(attr, obj, PolicyType::Leaf)
-                        }
-                        ret
-                    }
-                    PolicyType::Or => {
-                        let mut ret = false;
-                        for obj in arrayref.iter() {
-                            ret |= traverse_policy(attr, obj, PolicyType::Leaf)
-                        }
-                        ret
-                    }
-                    PolicyType::Leaf => false,
-                };
-            }
-        };
-}
-
-pub fn get_value(json: &PolicyValue) -> String {
+pub fn get_value(json: &PolicyNode) -> String {
     match json {
-        PolicyValue::String(node) => node_index(node),
+        PolicyNode::Leaf(node) => node_index(node),
         _ => "".to_string(),
     }
 }

--- a/crates/tessera-policy/src/error.rs
+++ b/crates/tessera-policy/src/error.rs
@@ -14,7 +14,12 @@ pub enum PolicyParserError {
     Empty,
     #[error("invalid policy type")]
     InvalidPolicyType,
+    #[error(transparent)]
+    MonotoneSpanProgram(#[from] MonotoneSpanProgramError),
 }
+
+#[derive(Debug, Error)]
+pub enum MonotoneSpanProgramError {}
 
 impl From<PestError<JsonRule>> for PolicyParserError {
     fn from(error: PestError<JsonRule>) -> Self {

--- a/crates/tessera-policy/src/pest/json.rs
+++ b/crates/tessera-policy/src/pest/json.rs
@@ -1,47 +1,41 @@
-use crate::{
-    error::PolicyParserError,
-    pest::{PolicyType, PolicyValue},
-};
+use std::collections::HashMap;
+
+use crate::{error::PolicyParserError, pest::PolicyNode};
 use pest::iterators::Pair;
 
 #[derive(Parser)]
 #[grammar = "json.policy.pest"]
 pub(crate) struct JSONPolicyParser;
 
-pub(crate) fn parse(pair: Pair<Rule>) -> Result<PolicyValue, PolicyParserError> {
+pub(crate) fn parse<'a>(
+    pair: Pair<'a, Rule>,
+    attribute_index: &mut HashMap<&'a str, usize>,
+) -> Result<PolicyNode<'a>, PolicyParserError> {
     match pair.as_rule() {
         Rule::string | Rule::number => {
             let p = pair.into_inner().next().unwrap();
-            Ok(PolicyValue::String((p.as_str(), p.line_col().1)))
+            let index = attribute_index.entry(p.as_str()).and_modify(|i| *i += 1).or_insert(0);
+            Ok(PolicyNode::Leaf((p.as_str(), *index)))
         }
         Rule::and => {
             let mut vec = Vec::new();
             for child in pair.into_inner() {
-                vec.push(parse(child)?);
+                vec.push(parse(child, attribute_index)?);
             }
-            Ok(PolicyValue::Object((PolicyType::And, Box::new(PolicyValue::Array(vec)))))
+
+            debug_assert!(vec.len() > 1);
+            let first = vec.split_off(1);
+            Ok(vec.into_iter().fold(first[0].clone(), |acc, x| PolicyNode::And((Box::new(acc), Box::new(x)))))
         }
         Rule::or => {
             let mut vec = Vec::new();
             for child in pair.into_inner() {
-                vec.push(parse(child)?);
+                vec.push(parse(child, attribute_index)?);
             }
-            Ok(PolicyValue::Object((PolicyType::Or, Box::new(PolicyValue::Array(vec)))))
+            debug_assert!(vec.len() > 1);
+            let first = vec.split_off(1);
+            Ok(vec.into_iter().fold(first[0].clone(), |acc, x| PolicyNode::Or((Box::new(acc), Box::new(x)))))
         }
-        Rule::content
-        | Rule::EOI
-        | Rule::inner
-        | Rule::orinner
-        | Rule::andinner
-        | Rule::node
-        | Rule::value
-        | Rule::andvalue
-        | Rule::orvalue
-        | Rule::char
-        | Rule::NAME
-        | Rule::CHILDREN
-        | Rule::COMMENT
-        | Rule::QUOTE
-        | Rule::WHITESPACE => Err(PolicyParserError::InvalidPolicyType),
+        _ => Err(PolicyParserError::InvalidPolicyType),
     }
 }


### PR DESCRIPTION
# refactor(policy): policy tree nodes to construct with a b-tree

<!-- Thank you for submitting a pull request to our repo. -->

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.



## Description

This pull request refactors the policy tree nodes to be constructed using a b-tree structure. This change aims to enable the construction of a Monotone Span Program (MSP)

