### PR TITLE
feat: add MonotoneSpanProgram(MSP) for policy 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,12 +2241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "permutation"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
-
-[[package]]
 name = "pest"
 version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,7 +3738,6 @@ dependencies = [
 name = "tessera-policy"
 version = "0.0.1"
 dependencies = [
- "permutation",
  "pest",
  "pest_derive",
  "serde",

--- a/crates/tessera-abe/src/utils/mod.rs
+++ b/crates/tessera-abe/src/utils/mod.rs
@@ -1,3 +1,2 @@
 pub mod aes;
 pub mod secret_shares;
-pub mod tools;

--- a/crates/tessera-policy/Cargo.toml
+++ b/crates/tessera-policy/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-permutation = "0.4.1"
 pest = "2.7.10"
 pest_derive = "2.7.10"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/tessera-policy/src/lib.rs
+++ b/crates/tessera-policy/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod error;
+pub mod msp;
 pub mod pest;
+pub mod utils;
 
 #[macro_use]
 extern crate pest_derive;

--- a/crates/tessera-policy/src/msp.rs
+++ b/crates/tessera-policy/src/msp.rs
@@ -1,0 +1,100 @@
+use crate::{pest::PolicyNode, utils::node_index};
+use std::collections::HashMap;
+
+const ZERO: i8 = 0;
+const PLUS: i8 = 1;
+const MINUS: i8 = -1;
+
+pub struct MonotoneSpanProgram {
+    pub matrix: HashMap<String, Vec<i8>>,
+    pub column_size: usize,
+}
+
+impl MonotoneSpanProgram {
+    pub fn new() -> Self {
+        MonotoneSpanProgram { matrix: HashMap::new(), column_size: 1 }
+    }
+
+    pub fn construct(&mut self, node: &PolicyNode, current_vector: &[i8]) {
+        match node {
+            PolicyNode::Leaf(attr) => {
+                self.matrix.insert(node_index(attr), current_vector.to_vec());
+            }
+            PolicyNode::Or((left, right)) => {
+                self.construct(left, current_vector);
+                self.construct(right, current_vector);
+            }
+            PolicyNode::And((left, right)) => {
+                let mut left_vector = current_vector.to_vec();
+                left_vector.resize(self.column_size, ZERO);
+                left_vector.push(PLUS);
+                let mut right_vector = vec![];
+                right_vector.resize(self.column_size, ZERO);
+                right_vector.push(MINUS);
+
+                self.column_size += 1;
+                self.construct(left, &left_vector);
+                self.construct(right, &right_vector);
+            }
+        }
+    }
+}
+
+impl<'a> From<PolicyNode<'a>> for MonotoneSpanProgram {
+    fn from(value: PolicyNode<'a>) -> Self {
+        MonotoneSpanProgram::from(&value)
+    }
+}
+
+impl<'a> From<&'a PolicyNode<'a>> for MonotoneSpanProgram {
+    fn from(value: &'a PolicyNode<'a>) -> Self {
+        let mut v: Vec<i8> = Vec::new();
+        let mut msp = MonotoneSpanProgram::new();
+        v.push(PLUS);
+        msp.construct(&value, &v);
+        for val in msp.matrix.values_mut() {
+            val.resize(msp.column_size, ZERO);
+        }
+        msp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::pest::{parse, PolicyLanguage};
+
+    use super::*;
+
+    #[test]
+    fn test_msp_simple_version() {
+        let policy = r#"("X@A" OR "A@B") AND ("A@B" OR "C@B")"#;
+        let policy = parse(policy, PolicyLanguage::HumanPolicy).expect("unsuccessful parse").0;
+        let msp: MonotoneSpanProgram = policy.into();
+
+        let mut matrix = HashMap::new();
+        matrix.insert("X@A_0".to_string(), vec![1, 1]);
+        matrix.insert("A@B_0".to_string(), vec![1, 1]);
+        matrix.insert("A@B_1".to_string(), vec![0, -1]);
+        matrix.insert("C@B_0".to_string(), vec![0, -1]);
+
+        assert_eq!(msp.matrix, matrix);
+    }
+
+    #[test]
+    fn test_msp_complicated_version() {
+        let policy = r#"("X@A" OR "A@B") AND (("X@A" AND "Y@A" AND "Z@A") AND ("A@B" OR "C@B"))"#;
+        let policy = parse(policy, PolicyLanguage::HumanPolicy).expect("unsuccessful parse").0;
+        let msp = MonotoneSpanProgram::from(&policy);
+
+        let mut matrix = HashMap::new();
+        matrix.insert("X@A_0".to_string(), vec![1, 1, 0, 0, 0]);
+        matrix.insert("X@A_1".to_string(), vec![0, -1, 1, 1, 1]);
+        matrix.insert("Y@A_0".to_string(), vec![0, 0, 0, 0, -1]);
+        matrix.insert("Z@A_0".to_string(), vec![0, 0, 0, -1, 0]);
+        matrix.insert("A@B_0".to_string(), vec![1, 1, 0, 0, 0]);
+        matrix.insert("A@B_1".to_string(), vec![0, 0, -1, 0, 0]);
+        matrix.insert("C@B_0".to_string(), vec![0, 0, -1, 0, 0]);
+
+        assert_eq!(msp.matrix, matrix);
+    }
+}

--- a/crates/tessera-policy/src/msp.rs
+++ b/crates/tessera-policy/src/msp.rs
@@ -10,6 +10,12 @@ pub struct MonotoneSpanProgram {
     pub column_size: usize,
 }
 
+impl Default for MonotoneSpanProgram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MonotoneSpanProgram {
     pub fn new() -> Self {
         MonotoneSpanProgram { matrix: HashMap::new(), column_size: 1 }
@@ -51,7 +57,7 @@ impl<'a> From<&'a PolicyNode<'a>> for MonotoneSpanProgram {
         let mut v: Vec<i8> = Vec::new();
         let mut msp = MonotoneSpanProgram::new();
         v.push(PLUS);
-        msp.construct(&value, &v);
+        msp.construct(value, &v);
         for val in msp.matrix.values_mut() {
             val.resize(msp.column_size, ZERO);
         }

--- a/crates/tessera-policy/src/pest/human.rs
+++ b/crates/tessera-policy/src/pest/human.rs
@@ -22,10 +22,9 @@ pub(crate) fn parse<'a>(
             for child in pair.into_inner() {
                 vec.push(parse(child, attribute_index)?);
             }
-
             debug_assert!(vec.len() > 1);
-            let first = vec.split_off(1);
-            Ok(vec.into_iter().fold(first[0].clone(), |acc, x| PolicyNode::And((Box::new(acc), Box::new(x)))))
+            let rest = vec.split_off(1);
+            Ok(rest.into_iter().fold(vec[0].clone(), |acc, x| PolicyNode::And((Box::new(acc), Box::new(x)))))
         }
         Rule::or => {
             let mut vec = Vec::new();
@@ -33,8 +32,8 @@ pub(crate) fn parse<'a>(
                 vec.push(parse(child, attribute_index)?);
             }
             debug_assert!(vec.len() > 1);
-            let first = vec.split_off(1);
-            Ok(vec.into_iter().fold(first[0].clone(), |acc, x| PolicyNode::Or((Box::new(acc), Box::new(x)))))
+            let rest = vec.split_off(1);
+            Ok(rest.into_iter().fold(vec[0].clone(), |acc, x| PolicyNode::Or((Box::new(acc), Box::new(x)))))
         }
         _ => Err(PolicyParserError::InvalidPolicyType),
     }

--- a/crates/tessera-policy/src/pest/json.rs
+++ b/crates/tessera-policy/src/pest/json.rs
@@ -24,8 +24,8 @@ pub(crate) fn parse<'a>(
             }
 
             debug_assert!(vec.len() > 1);
-            let first = vec.split_off(1);
-            Ok(vec.into_iter().fold(first[0].clone(), |acc, x| PolicyNode::And((Box::new(acc), Box::new(x)))))
+            let rest = vec.split_off(1);
+            Ok(rest.into_iter().fold(vec[0].clone(), |acc, x| PolicyNode::And((Box::new(acc), Box::new(x)))))
         }
         Rule::or => {
             let mut vec = Vec::new();
@@ -33,8 +33,8 @@ pub(crate) fn parse<'a>(
                 vec.push(parse(child, attribute_index)?);
             }
             debug_assert!(vec.len() > 1);
-            let first = vec.split_off(1);
-            Ok(vec.into_iter().fold(first[0].clone(), |acc, x| PolicyNode::Or((Box::new(acc), Box::new(x)))))
+            let rest = vec.split_off(1);
+            Ok(rest.into_iter().fold(vec[0].clone(), |acc, x| PolicyNode::Or((Box::new(acc), Box::new(x)))))
         }
         _ => Err(PolicyParserError::InvalidPolicyType),
     }

--- a/crates/tessera-policy/src/utils.rs
+++ b/crates/tessera-policy/src/utils.rs
@@ -1,10 +1,15 @@
-use crate::utils::secret_shares::node_index;
+use crate::pest::PolicyNode;
 use std::collections::HashSet;
-use tessera_policy::pest::PolicyNode;
 
-pub fn is_negative(attr: &str) -> bool {
-    let first_char = &attr[..1];
-    first_char == '!'.to_string()
+pub fn node_index(node: &(&str, usize)) -> String {
+    format!("{}_{}", node.0, node.1)
+}
+pub fn remove_index(node: &str) -> String {
+    let mut parts: Vec<_> = node.split('_').collect();
+    if parts.len() > 1 {
+        parts.pop();
+    }
+    parts.join("_")
 }
 
 #[inline]


### PR DESCRIPTION
# feat: add MonotoneSpanProgram(MSP) for policy

<!-- Thank you for submitting a pull request to our repo. -->

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.



## Description

This pull request introduces the MonotoneSpanProgram (MSP) functionality for policies. These changes were made to implement schemes that utilize Monotone Span Programs (MSP).