### PR TITLE
feat(abe): integrate Bn462 pairing-friendly curve

### DIFF
--- a/crates/tessera-abe/src/curves/bn462.rs
+++ b/crates/tessera-abe/src/curves/bn462.rs
@@ -1,0 +1,503 @@
+use std::{
+    iter::Sum,
+    ops::{Add, Div, Mul, Neg, Sub},
+};
+
+use crate::random::{miracl::MiraclRng, Random};
+
+use super::{
+    Field, FieldWithOrder, GroupG1, GroupG2, GroupGt, Inv, PairingCurve, Pow, RefAdd, RefDiv, RefMul, RefNeg, RefPow,
+    RefSub,
+};
+use lazy_static::lazy_static;
+
+use rand_core::RngCore as _;
+use serde::{Deserialize, Serialize};
+use tessera_miracl::{
+    bn462::{
+        big::{BIG, MODBYTES, NLEN},
+        ecp::ECP,
+        ecp2::ECP2,
+        fp12::FP12,
+        pair,
+        rom::CURVE_ORDER,
+    },
+    hash256::HASH256,
+};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Bn462Field {
+    inner: BIG,
+}
+
+const MODULUS: [i64; NLEN] = CURVE_ORDER;
+const MSG_SIZE: usize = 48 * MODBYTES;
+
+lazy_static! {
+    pub static ref MODULUS_BIG: BIG = BIG::new_ints(&MODULUS);
+}
+
+impl Field for Bn462Field {
+    type Chunk = i64;
+
+    #[inline]
+    fn new() -> Self {
+        Self { inner: BIG::new() }
+    }
+
+    #[inline]
+    fn one() -> Self {
+        Self { inner: BIG::new_int(1) }
+    }
+
+    #[inline]
+    fn new_int(x: Self::Chunk) -> Self {
+        Self { inner: BIG::new_int(x as isize) }
+    }
+
+    #[inline]
+    fn new_ints(x: &[Self::Chunk]) -> Self {
+        Self { inner: BIG::new_ints(x) }
+    }
+}
+
+impl From<u64> for Bn462Field {
+    #[inline]
+    fn from(x: u64) -> Self {
+        Self { inner: BIG::new_int(x as isize) }
+    }
+}
+
+impl Random for Bn462Field {
+    type Rng = MiraclRng;
+
+    #[inline]
+    fn random(rng: &mut Self::Rng) -> Self {
+        Self { inner: BIG::random(&mut rng.inner) }
+    }
+}
+
+impl FieldWithOrder for Bn462Field {
+    #[inline]
+    fn order() -> Self {
+        Self { inner: *MODULUS_BIG }
+    }
+    #[inline]
+    fn random_within_order(rng: &mut <Self as Random>::Rng) -> Self {
+        let mut r = BIG::random(&mut rng.inner);
+        r.rmod(&MODULUS_BIG);
+        Self { inner: r }
+    }
+}
+
+impl Sum<Bn462Field> for Bn462Field {
+    fn sum<I: Iterator<Item = Bn462Field>>(iter: I) -> Self {
+        iter.fold(Self::new(), |acc, x| acc + x)
+    }
+}
+
+impl Add for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: Self) -> Self {
+        self.ref_add(&other)
+    }
+}
+
+impl RefAdd for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn ref_add(&self, other: &Self) -> Self {
+        Self { inner: BIG::modadd(&self.inner, &other.inner, &MODULUS_BIG) }
+    }
+}
+
+impl Div for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn div(self, mut other: Self) -> Self {
+        other.inner.invmodp(&MODULUS_BIG);
+        Self { inner: BIG::modmul(&self.inner, &other.inner, &MODULUS_BIG) }
+    }
+}
+
+impl RefDiv for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn ref_div(&self, other: &Self) -> Self {
+        let mut other = other.inner;
+        other.invmodp(&MODULUS_BIG);
+        Self { inner: BIG::modmul(&self.inner, &other, &MODULUS_BIG) }
+    }
+}
+
+impl Mul for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, other: Self) -> Self {
+        self.ref_mul(&other)
+    }
+}
+
+impl RefMul for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn ref_mul(&self, other: &Self) -> Self {
+        Self { inner: BIG::modmul(&self.inner, &other.inner, &MODULUS_BIG) }
+    }
+}
+
+impl Sub for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: Self) -> Self {
+        self.ref_sub(&other)
+    }
+}
+
+impl RefSub for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn ref_sub(&self, other: &Self) -> Self {
+        let neg_other = BIG::modneg(&other.inner, &MODULUS_BIG);
+        Self { inner: BIG::modadd(&self.inner, &neg_other, &MODULUS_BIG) }
+    }
+}
+
+impl Neg for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        self.ref_neg()
+    }
+}
+
+impl RefNeg for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn ref_neg(&self) -> Self {
+        Self { inner: BIG::modneg(&self.inner, &MODULUS_BIG) }
+    }
+}
+
+impl Pow for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn pow(mut self, e: &Self) -> Self {
+        Self { inner: self.inner.powmod(&e.inner, &MODULUS_BIG) }
+    }
+}
+
+impl RefPow for Bn462Field {
+    type Output = Self;
+
+    #[inline]
+    fn ref_pow(&self, e: &Self) -> Self {
+        self.clone().pow(e)
+    }
+}
+
+impl PartialEq for Bn462Field {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        BIG::comp(&self.inner, &other.inner) == 0
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct G1 {
+    inner: ECP,
+}
+
+impl GroupG1 for G1 {
+    type Field = Bn462Field;
+
+    #[inline]
+    fn new(x: &Self::Field) -> Self {
+        Self::generator() * x
+    }
+
+    #[inline]
+    fn zero() -> Self {
+        Self { inner: ECP::new() }
+    }
+
+    #[inline]
+    fn generator() -> Self {
+        Self { inner: ECP::generator() }
+    }
+}
+
+impl Mul<Bn462Field> for G1 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Bn462Field) -> Self {
+        self.ref_mul(&rhs)
+    }
+}
+
+impl Mul<&Bn462Field> for G1 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: &Bn462Field) -> Self {
+        self.ref_mul(rhs)
+    }
+}
+
+impl RefMul<Bn462Field> for G1 {
+    type Output = Self;
+
+    #[inline]
+    fn ref_mul(&self, rhs: &Bn462Field) -> Self {
+        Self { inner: pair::g1mul(&self.inner, &rhs.inner) }
+    }
+}
+
+impl Add for G1 {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: Self) -> Self {
+        self + &other
+    }
+}
+
+impl Add<&G1> for G1 {
+    type Output = Self;
+
+    #[inline]
+    fn add(mut self, other: &Self) -> Self {
+        self.inner.add(&other.inner);
+        self
+    }
+}
+
+impl RefAdd for G1 {
+    type Output = Self;
+
+    #[inline]
+    fn ref_add(&self, other: &Self) -> Self {
+        self.clone() + other
+    }
+}
+
+impl Neg for G1 {
+    type Output = Self;
+
+    #[inline]
+    fn neg(mut self) -> Self {
+        self.inner.neg();
+        self
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct G2 {
+    inner: ECP2,
+}
+
+impl GroupG2 for G2 {
+    type Field = Bn462Field;
+
+    fn new(x: &Self::Field) -> Self {
+        Self::generator() * x
+    }
+
+    fn generator() -> Self {
+        Self { inner: ECP2::generator() }
+    }
+}
+
+impl Mul<Bn462Field> for G2 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Bn462Field) -> Self {
+        self.ref_mul(&rhs)
+    }
+}
+
+impl Mul<&Bn462Field> for G2 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: &Bn462Field) -> Self {
+        self.ref_mul(rhs)
+    }
+}
+
+impl RefMul<Bn462Field> for G2 {
+    type Output = Self;
+
+    #[inline]
+    fn ref_mul(&self, rhs: &Bn462Field) -> Self {
+        Self { inner: pair::g2mul(&self.inner, &rhs.inner) }
+    }
+}
+
+impl Add for G2 {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: Self) -> Self {
+        self + &other
+    }
+}
+
+impl Add<&G2> for G2 {
+    type Output = Self;
+
+    #[inline]
+    fn add(mut self, other: &Self) -> Self {
+        self.inner.add(&other.inner);
+        self
+    }
+}
+
+impl RefAdd for G2 {
+    type Output = Self;
+
+    #[inline]
+    fn ref_add(&self, other: &Self) -> Self {
+        self.clone() + other
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Gt {
+    inner: FP12,
+}
+
+impl GroupGt for Gt {
+    type Field = Bn462Field;
+
+    #[inline]
+    fn one() -> Self {
+        let mut r = FP12::new();
+        r.one();
+        Self { inner: r }
+    }
+}
+
+impl From<Gt> for Vec<u8> {
+    #[inline]
+    fn from(gt: Gt) -> Self {
+        let mut bytes = vec![0u8; MSG_SIZE];
+        gt.inner.tobytes(&mut bytes);
+        bytes
+    }
+}
+
+impl<'a> From<&'a [u8]> for Gt {
+    #[inline]
+    fn from(bytes: &'a [u8]) -> Self {
+        Self { inner: FP12::frombytes(bytes) }
+    }
+}
+
+impl Random for Gt {
+    type Rng = MiraclRng;
+    fn random(rng: &mut Self::Rng) -> Self {
+        let mut rand_bytes = [0u8; MSG_SIZE];
+        rng.fill_bytes(&mut rand_bytes);
+        let r = FP12::frombytes(&rand_bytes);
+        Self { inner: r }
+    }
+}
+
+impl Mul for Gt {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, other: Self) -> Self {
+        self * &other
+    }
+}
+
+impl Mul<&Self> for Gt {
+    type Output = Self;
+
+    #[inline]
+    fn mul(mut self, rhs: &Self) -> Self {
+        self.inner.mul(&rhs.inner);
+        self
+    }
+}
+
+impl RefMul for Gt {
+    type Output = Self;
+
+    #[inline]
+    fn ref_mul(&self, rhs: &Self) -> Self {
+        self.clone() * rhs
+    }
+}
+
+impl Pow<Bn462Field> for Gt {
+    type Output = Self;
+
+    #[inline]
+    fn pow(self, rhs: &Bn462Field) -> Self {
+        self.ref_pow(rhs)
+    }
+}
+
+impl RefPow<Bn462Field> for Gt {
+    type Output = Self;
+
+    #[inline]
+    fn ref_pow(&self, rhs: &Bn462Field) -> Self {
+        Self { inner: pair::gtpow(&self.inner, &rhs.inner) }
+    }
+}
+
+impl Inv for Gt {
+    type Output = Self;
+
+    fn inverse(mut self) -> Self {
+        self.inner.inverse();
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Bn462Curve;
+
+impl PairingCurve for Bn462Curve {
+    type Rng = MiraclRng;
+    type Field = Bn462Field;
+    type G1 = G1;
+    type G2 = G2;
+    type Gt = Gt;
+
+    fn pair(e1: &Self::G1, e2: &Self::G2) -> Self::Gt {
+        Self::Gt { inner: pair::fexp(&pair::ate(&e2.inner, &e1.inner)) }
+    }
+
+    fn hash_to_g1(msg: &[u8]) -> Self::G1 {
+        let mut hash = HASH256::new();
+        hash.process_array(msg);
+        let h = hash.hash();
+        Self::G1 { inner: ECP::mapit(&h) }
+    }
+
+    fn hash_to_g2(msg: &[u8]) -> Self::G2 {
+        let mut hash = HASH256::new();
+        hash.process_array(msg);
+        let h = hash.hash();
+        Self::G2 { inner: ECP2::mapit(&h) }
+    }
+}

--- a/crates/tessera-abe/src/curves/mod.rs
+++ b/crates/tessera-abe/src/curves/mod.rs
@@ -1,5 +1,6 @@
 pub mod bls24479;
 pub mod bls48556;
+pub mod bn462;
 
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};

--- a/crates/tessera-abe/src/schemes/isabella24.rs
+++ b/crates/tessera-abe/src/schemes/isabella24.rs
@@ -339,7 +339,7 @@ mod tests {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::{curves::bls24479::Bls24479Curve, random::miracl::MiraclRng};
+    use crate::{curves::bn462::Bn462Curve, random::miracl::MiraclRng};
     use rstest::*;
 
     fn rng() -> MiraclRng {
@@ -352,28 +352,28 @@ mod tests {
 
     #[fixture]
     #[once]
-    fn gp() -> GlobalParams<Bls24479Curve> {
+    fn gp() -> GlobalParams<Bn462Curve> {
         let mut rng = rng();
-        GlobalParams::<Bls24479Curve>::new(&mut rng)
+        GlobalParams::<Bn462Curve>::new(&mut rng)
     }
 
     #[fixture]
     #[once]
-    fn authority_a(gp: &GlobalParams<Bls24479Curve>) -> AuthorityKeyPair<Bls24479Curve> {
+    fn authority_a(gp: &GlobalParams<Bn462Curve>) -> AuthorityKeyPair<Bn462Curve> {
         let mut rng = rng();
         AuthorityKeyPair::new(&mut rng, gp, "A")
     }
 
     #[fixture]
     #[once]
-    fn authority_b(gp: &GlobalParams<Bls24479Curve>) -> AuthorityKeyPair<Bls24479Curve> {
+    fn authority_b(gp: &GlobalParams<Bn462Curve>) -> AuthorityKeyPair<Bn462Curve> {
         let mut rng = rng();
         AuthorityKeyPair::new(&mut rng, gp, "B")
     }
 
     #[fixture]
     #[once]
-    fn authority_c(gp: &GlobalParams<Bls24479Curve>) -> AuthorityKeyPair<Bls24479Curve> {
+    fn authority_c(gp: &GlobalParams<Bn462Curve>) -> AuthorityKeyPair<Bn462Curve> {
         let mut rng = rng();
         AuthorityKeyPair::new(&mut rng, gp, "C")
     }
@@ -381,10 +381,10 @@ mod tests {
     #[fixture]
     #[once]
     fn alice(
-        gp: &GlobalParams<Bls24479Curve>,
-        authority_a: &AuthorityKeyPair<Bls24479Curve>,
-        authority_b: &AuthorityKeyPair<Bls24479Curve>,
-    ) -> UserSecretKey<Bls24479Curve> {
+        gp: &GlobalParams<Bn462Curve>,
+        authority_a: &AuthorityKeyPair<Bn462Curve>,
+        authority_b: &AuthorityKeyPair<Bn462Curve>,
+    ) -> UserSecretKey<Bn462Curve> {
         let mut rng = rng();
         let mut alice = UserSecretKey::new(&mut rng, gp, &authority_a.mk, "alice", &["ADMIN", "INFRA", "LEVEL_3"]);
         alice.add_attribute_key(&mut rng, gp, &authority_b.mk, &["CTO", "PROFESSOR"]);
@@ -394,10 +394,10 @@ mod tests {
     #[fixture]
     #[once]
     fn bob(
-        gp: &GlobalParams<Bls24479Curve>,
-        authority_a: &AuthorityKeyPair<Bls24479Curve>,
-        authority_c: &AuthorityKeyPair<Bls24479Curve>,
-    ) -> UserSecretKey<Bls24479Curve> {
+        gp: &GlobalParams<Bn462Curve>,
+        authority_a: &AuthorityKeyPair<Bn462Curve>,
+        authority_c: &AuthorityKeyPair<Bn462Curve>,
+    ) -> UserSecretKey<Bn462Curve> {
         let mut rng = rng();
         let mut bob = UserSecretKey::new(&mut rng, gp, &authority_a.mk, "bob", &["USER", "LEVEL_2"]);
         bob.add_attribute_key(&mut rng, gp, &authority_c.mk, &["CEO"]);
@@ -419,12 +419,12 @@ mod tests {
         false
     )]
     fn isabella24_encrypt_and_decrypt(
-        gp: &GlobalParams<Bls24479Curve>,
-        authority_a: &AuthorityKeyPair<Bls24479Curve>,
-        authority_b: &AuthorityKeyPair<Bls24479Curve>,
-        authority_c: &AuthorityKeyPair<Bls24479Curve>,
-        alice: &UserSecretKey<Bls24479Curve>,
-        bob: &UserSecretKey<Bls24479Curve>,
+        gp: &GlobalParams<Bn462Curve>,
+        authority_a: &AuthorityKeyPair<Bn462Curve>,
+        authority_b: &AuthorityKeyPair<Bn462Curve>,
+        authority_c: &AuthorityKeyPair<Bn462Curve>,
+        alice: &UserSecretKey<Bn462Curve>,
+        bob: &UserSecretKey<Bn462Curve>,
         #[case] plaintext: &str,
         #[case] policy: &str,
         #[case] expected_alice: bool,

--- a/crates/tessera-miracl/src/bn462/big.rs
+++ b/crates/tessera-miracl/src/bn462/big.rs
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use crate::arch;
 use crate::arch::Chunk;
 
@@ -36,15 +39,9 @@ pub const HMASK: Chunk = (1 << HBITS) - 1;
 pub const NEXCESS: isize = 1 << ((arch::CHUNK) - BASEBITS - 1);
 pub const BIGBITS: usize = MODBYTES * 8;
 
-#[derive(Copy)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct BIG {
     pub w: [Chunk; NLEN],
-}
-
-impl Clone for BIG {
-    fn clone(&self) -> BIG {
-        *self
-    }
 }
 
 #[cfg(feature = "std")]

--- a/crates/tessera-miracl/src/bn462/ecp.rs
+++ b/crates/tessera-miracl/src/bn462/ecp.rs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use serde::{Deserialize, Serialize};
+
 use crate::bn462::big;
 use crate::bn462::big::BIG;
 use crate::bn462::dbig::DBIG;
@@ -24,7 +26,7 @@ use crate::bn462::fp;
 use crate::bn462::fp::FP;
 use crate::bn462::rom;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ECP {
     x: FP,
     y: FP,

--- a/crates/tessera-miracl/src/bn462/ecp2.rs
+++ b/crates/tessera-miracl/src/bn462/ecp2.rs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use serde::{Deserialize, Serialize};
+
 use crate::bn462::big;
 use crate::bn462::big::BIG;
 use crate::bn462::dbig::DBIG;
@@ -26,7 +28,7 @@ use crate::bn462::fp::FP;
 use crate::bn462::fp2::FP2;
 use crate::bn462::rom;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ECP2 {
     x: FP2,
     y: FP2,

--- a/crates/tessera-miracl/src/bn462/fp.rs
+++ b/crates/tessera-miracl/src/bn462/fp.rs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use serde::{Deserialize, Serialize};
+
 use crate::arch;
 use crate::arch::Chunk;
 use crate::bn462::big;
@@ -26,7 +28,7 @@ use crate::bn462::rom;
 
 use crate::rand::RAND;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct FP {
     pub x: BIG,
     pub xes: i32,

--- a/crates/tessera-miracl/src/bn462/fp12.rs
+++ b/crates/tessera-miracl/src/bn462/fp12.rs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use serde::{Deserialize, Serialize};
+
 use crate::bn462::big;
 use crate::bn462::big::BIG;
 use crate::bn462::ecp;
@@ -32,7 +34,7 @@ pub const SPARSER: usize = 3;
 pub const SPARSE: usize = 4;
 pub const DENSE: usize = 5;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct FP12 {
     a: FP4,
     b: FP4,
@@ -883,7 +885,7 @@ impl FP12 {
     }
 
     /* convert this to byte array */
-    pub fn tobytes(&mut self, w: &mut [u8]) {
+    pub fn tobytes(&self, w: &mut [u8]) {
         const MB: usize = 4 * big::MODBYTES;
         let mut t: [u8; MB] = [0; MB];
 

--- a/crates/tessera-miracl/src/bn462/fp2.rs
+++ b/crates/tessera-miracl/src/bn462/fp2.rs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use serde::{Deserialize, Serialize};
+
 use crate::bn462::big;
 use crate::bn462::big::BIG;
 use crate::bn462::dbig::DBIG;
@@ -26,7 +28,7 @@ use crate::bn462::rom;
 
 use crate::rand::RAND;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct FP2 {
     a: FP,
     b: FP,

--- a/crates/tessera-miracl/src/bn462/fp4.rs
+++ b/crates/tessera-miracl/src/bn462/fp4.rs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use serde::{Deserialize, Serialize};
+
 use crate::bn462::big;
 use crate::bn462::big::BIG;
 use crate::bn462::fp;
@@ -26,7 +28,7 @@ use crate::bn462::fp2::FP2;
 use crate::bn462::rom;
 use crate::rand::RAND;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub struct FP4 {
     a: FP2,
     b: FP2,


### PR DESCRIPTION
# feat(abe): integrate Bn462 pairing-friendly curve

<!-- Thank you for submitting a pull request to our repo. -->

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


## Description

This pull request introduces the integration of the Bn462 pairing-friendly curve, enhancing the capabilities of the ABE module. This feature aims to improve cryptographic operations by utilizing a lightweight pairing-friendly curve, thereby optimizing performance and resource efficiency. 


## Note
https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-11.html#section-4.2.2


